### PR TITLE
[Forms] Refactor `buttonCell` & `buttonDialogCell` to allow async action & cancellation

### DIFF
--- a/Examples/SherlockForms-Gallery.swiftpm/RootView.swift
+++ b/Examples/SherlockForms-Gallery.swiftpm/RootView.swift
@@ -133,6 +133,9 @@ struct RootView: View, SherlockView
                     icon: icon,
                     title: "Delete Caches",
                     action: {
+                        // Fake long task...
+                        try await Task.sleep(nanoseconds: 1_000_000_000)
+
                         try? Helper.deleteAllCaches()
                         showHUD(.init(message: "Finished deleting caches"))
                     }
@@ -144,17 +147,18 @@ struct RootView: View, SherlockView
                         icon: icon,
                         title: "Delete All Contents",
                         dialogTitle: nil,
-                        dialogButtons: { completion in
-                            Button("Delete All Contents", role: .destructive) {
+                        dialogButtons: [
+                            .init(title: "Delete All Contents", role: .destructive) {
+                                // Fake long task...
+                                try await Task.sleep(nanoseconds: 2_000_000_000)
+
                                 try? Helper.deleteAllFilesAndCaches()
                                 showHUD(.init(message: "Finished deleting all contents"))
-                                completion()
-                            }
-                            Button("Cancel", role: .cancel) {
+                            },
+                            .init(title: "Cancel", role: .cancel) {
                                 print("Cancelled")
-                                completion()
                             }
-                        }
+                        ]
                     )
                 }
                 else {


### PR DESCRIPTION
This PR supports async-action for `buttonCell` & `buttonDialogCell` with introducing `ButtonDialogCell.DialogButton` as a breaking change.

Loading indicator will be prompted during async action, and can be cancelled by tapping it.

## Screencast

https://user-images.githubusercontent.com/138476/154058323-cc29ccf1-4166-481d-9cfc-19bbeb1b5f4a.mp4