### PR TITLE
[DebugForm] Support hierarchical search results

### DIFF
--- a/Examples/SherlockForms-Gallery.swiftpm/RootView.swift
+++ b/Examples/SherlockForms-Gallery.swiftpm/RootView.swift
@@ -8,7 +8,7 @@ struct RootView: View, SherlockView
     /// NOTE:
     /// `searchText` is required for `SherlockView` protocol.
     /// This is the only requirement to define as `@State`, and pass it to `SherlockForm`.
-    @State public var searchText: String = ""
+    @State public private(set) var searchText: String = ""
 
     @AppStorage("username")
     private var username: String = "John Appleseed"
@@ -173,6 +173,24 @@ struct RootView: View, SherlockView
                     Text("Tip: Last button is ButtonDialog.")
                 }
             }
+
+            // Full-Text Search Result:
+            // Show navigationLink's search results as well.
+            if !searchText.isEmpty {
+                UserDefaultsListSectionsView(
+                    searchText: searchText,
+                    maxRecentlyUsedCount: 0,
+                    sectionHeader: { sectionHeader(prefixes: "UserDefaults", title: $0) }
+                )
+                AppInfoSectionsView(
+                    searchText: searchText,
+                    sectionHeader: { sectionHeader(prefixes: "App Info", title: $0) }
+                )
+                DeviceInfoSectionsView(
+                    searchText: searchText,
+                    sectionHeader: { sectionHeader(prefixes: "Device Info", title: $0) }
+                )
+            }
         }
         .navigationTitle("Settings")
         // NOTE:
@@ -211,6 +229,11 @@ struct RootView: View, SherlockView
                     }
             }
     }
+}
+
+private func sectionHeader(prefixes: String..., title: String) -> String
+{
+    (prefixes + [title]).filter { !$0.isEmpty }.joined(separator: " > ")
 }
 
 // MARK: - Previews

--- a/Sources/SherlockDebugForms/AppInfoView.swift
+++ b/Sources/SherlockDebugForms/AppInfoView.swift
@@ -1,33 +1,51 @@
 import SwiftUI
 
-public struct AppInfoView: View, SherlockView
+/// Screen for presenting Application-level information, e.g. App name, build version, bundler-identifier.
+public struct AppInfoView: View
 {
-    @State public var searchText: String = ""
+    @State public private(set) var searchText: String = ""
 
     public init() {}
 
     public var body: some View
     {
         SherlockForm(searchText: $searchText) {
-            Section {
-                _body
-            }
+            AppInfoSectionsView(searchText: searchText)
         }
         .formCellCopyable(true)
         .navigationTitle("App Info")
         .navigationBarTitleDisplayMode(.inline)
     }
+}
 
-    @ViewBuilder
-    private var _body: some View
+/// AppInfo `Section`s, useful for presenting search results from ancestor screens.
+public struct AppInfoSectionsView: View, SherlockView
+{
+    public let searchText: String
+    private let sectionHeader: (String) -> String
+
+    public init(
+        searchText: String,
+        sectionHeader: @escaping (String) -> String = { $0 }
+    )
     {
-        textCell(title: "App Name", value: Application.current.appName)
-        textCell(title: "Version", value: Application.current.version)
-        textCell(title: "Build", value: Application.current.build)
-        textCell(title: "Bundle ID", value: Application.current.bundleIdentifier)
-        textCell(title: "App Size", value: Application.current.size)
-        textCell(title: "Locale", value: Application.current.locale)
-        textCell(title: "Localization", value: Application.current.preferredLocalizations)
-        textCell(title: "TestFlight?", value: Application.current.isTestFlight)
+        self.searchText = searchText
+        self.sectionHeader = sectionHeader
+    }
+
+    public var body: some View
+    {
+        Section {
+            textCell(title: "App Name", value: Application.current.appName)
+            textCell(title: "Version", value: Application.current.version)
+            textCell(title: "Build", value: Application.current.build)
+            textCell(title: "Bundle ID", value: Application.current.bundleIdentifier)
+            textCell(title: "App Size", value: Application.current.size)
+            textCell(title: "Locale", value: Application.current.locale)
+            textCell(title: "Localization", value: Application.current.preferredLocalizations)
+            textCell(title: "TestFlight?", value: Application.current.isTestFlight)
+        } header: {
+            sectionHeaderView(sectionHeader(""))
+        }
     }
 }

--- a/Sources/SherlockDebugForms/DeviceInfoView.swift
+++ b/Sources/SherlockDebugForms/DeviceInfoView.swift
@@ -1,26 +1,42 @@
 import SwiftUI
 import Combine
 
+/// Screen for presenting Device-level information, e.g. Device name, system version, disk usage.
 public struct DeviceInfoView: View, SherlockView
 {
-    @StateObject private var timer: TimerWrapper = .init()
-
-    @State public var searchText: String = ""
+    @State public private(set) var searchText: String = ""
 
     public init() {}
 
     public var body: some View
     {
         SherlockForm(searchText: $searchText) {
-            _body
+            DeviceInfoSectionsView(searchText: searchText)
         }
         .formCellCopyable(true)
         .navigationTitle("Device Info")
         .navigationBarTitleDisplayMode(.inline)
     }
+}
 
-    @ViewBuilder
-    private var _body: some View
+/// DeviceInfo `Section`s, useful for presenting search results from ancestor screens.
+public struct DeviceInfoSectionsView: View, SherlockView
+{
+    @StateObject private var timer: TimerWrapper = .init()
+
+    public let searchText: String
+    private let sectionHeader: (String) -> String
+
+    public init(
+        searchText: String,
+        sectionHeader: @escaping (String) -> String = { $0 }
+    )
+    {
+        self.searchText = searchText
+        self.sectionHeader = sectionHeader
+    }
+
+    public var body: some View
     {
         Section {
             textCell(title: "Model", value: Device.current.localizedModel)
@@ -30,7 +46,7 @@ public struct DeviceInfoView: View, SherlockView
             textCell(title: "Jailbreak?", value: Device.current.isJailbreaked)
             textCell(title: "Low Power Mode?", value: Device.current.isLowPowerModeEnabled)
         } header: {
-            Text("General")
+            sectionHeaderView(sectionHeader("General"))
         }
 
         Section {
@@ -43,7 +59,7 @@ public struct DeviceInfoView: View, SherlockView
             textCell(title: "Battery", value: "\(Device.current.localizedBatteryLevel) / \(Device.current.localizedBatteryState)")
             textCell(title: "Thermal State", value: Device.current.localizedThermalState)
         } header: {
-            Text("Usage")
+            sectionHeaderView(sectionHeader("Usage"))
         }
 
         Group {

--- a/Sources/SherlockDebugForms/Internals/View+SectionHeader.swift
+++ b/Sources/SherlockDebugForms/Internals/View+SectionHeader.swift
@@ -1,0 +1,11 @@
+import SwiftUI
+
+extension View
+{
+    @ViewBuilder
+    func sectionHeaderView(_ text: String) -> some View
+    {
+        if text.isEmpty { EmptyView() }
+        else { Text(text) }
+    }
+}

--- a/Sources/SherlockDebugForms/UserDefaultsItemView.swift
+++ b/Sources/SherlockDebugForms/UserDefaultsItemView.swift
@@ -54,5 +54,5 @@ struct UserDefaultsItemView: View, SherlockView
         }
     }
 
-    typealias KeyValue = UserDefaultsListView.KeyValue
+    typealias KeyValue = UserDefaultsListSectionsView.KeyValue
 }


### PR DESCRIPTION
This PR decouples `SherlockDebugForm`'s:

- `UserDefaultsListView` / `AppInfoView` / `DeviceInfoView` that holds `@State var searchText` 

into:

- `UserDefaultsSectionsListView` / `AppInfoSectionsView` / `DeviceInfoSectionsView` with `@Binding var searchText`

so that sections can be reused for showing search results in its ancestor view, and allows hierarchical search.
(This behavior is similar to how iOS's Settings.app handles hierarchical searching)

### Screenshot

<img src=https://user-images.githubusercontent.com/138476/154174544-0063c67d-77d5-467b-8d36-5393477b752e.PNG  width=300>


