### PR TITLE
Improve `showHUD` thread-safety by adding `@MainActor` & `@Sendable`

### DIFF
--- a/Examples/SherlockForms-Gallery.swiftpm/RootView.swift
+++ b/Examples/SherlockForms-Gallery.swiftpm/RootView.swift
@@ -36,7 +36,7 @@ struct RootView: View, SherlockView
     /// Attaching `.enableSherlockHUD(true)` to topmost view will allow using `showHUD`.
     /// See `SherlockHUD` module for more information.
     @Environment(\.showHUD)
-    private var showHUD: (HUDMessage) -> Void
+    private var showHUD: @MainActor (HUDMessage) -> Void
 
     var body: some View
     {

--- a/Examples/SherlockHUD-Demo.swiftpm/RootView.swift
+++ b/Examples/SherlockHUD-Demo.swiftpm/RootView.swift
@@ -8,7 +8,7 @@ struct RootView: View
     /// Attaching `.enableSherlockHUD(true)` to topmost view will allow using `showHUD`.
     /// See `SherlockHUD` module for more information.
     @Environment(\.showHUD)
-    private var showHUD: (HUDMessage) -> Void
+    private var showHUD: @MainActor (HUDMessage) -> Void
 
     var body: some View
     {

--- a/Sources/SherlockDebugForms/UserDefaultsListView.swift
+++ b/Sources/SherlockDebugForms/UserDefaultsListView.swift
@@ -70,7 +70,7 @@ public struct UserDefaultsListSectionsView: View, SherlockView
     private let sectionHeader: (String) -> String
 
     @Environment(\.showHUD)
-    private var showHUD: (HUDMessage) -> Void
+    private var showHUD: @MainActor (HUDMessage) -> Void
 
     public init(
         searchText: String,

--- a/Sources/SherlockForms/FormCells/ButtonDialogCell.swift
+++ b/Sources/SherlockForms/FormCells/ButtonDialogCell.swift
@@ -117,16 +117,16 @@ public struct ButtonDialogCell: View
 @available(iOS 15.0, *)
 extension ButtonDialogCell
 {
-    public struct DialogButton
+    public struct DialogButton: Sendable
     {
         let title: String
         let role: ButtonRole?
-        let action: () async throws -> Void
+        let action: @MainActor @Sendable () async throws -> Void
 
         public init(
             title: String,
             role: ButtonRole? = nil,
-            action: @escaping () async throws -> Void
+            action: @MainActor @Sendable @escaping () async throws -> Void
         )
         {
             self.title = title

--- a/Sources/SherlockForms/Internals/CopyableViewModifier.swift
+++ b/Sources/SherlockForms/Internals/CopyableViewModifier.swift
@@ -1,13 +1,14 @@
 import SwiftUI
 
 /// `ViewModifier` for showing "Copy (key & value)" context-menu.
+@MainActor
 struct CopyableViewModifier: ViewModifier
 {
     private let key: String
     private let value: String?
 
     @Environment(\.showHUD)
-    private var showHUD: (HUDMessage) -> Void
+    private var showHUD: @MainActor (HUDMessage) -> Void
 
     init(key: String, value: String? = nil)
     {

--- a/Sources/SherlockForms/UncheckedSendable.swift
+++ b/Sources/SherlockForms/UncheckedSendable.swift
@@ -1,0 +1,6 @@
+// TODO: Remove `@unchecked Sendable` when `Sendable` is supported by each module.
+
+import SwiftUI
+
+@available(iOS 15.0, *)
+extension ButtonRole: @unchecked Sendable {}

--- a/Sources/SherlockHUD/ShowHUDEnvironmentKey.swift
+++ b/Sources/SherlockHUD/ShowHUDEnvironmentKey.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 extension EnvironmentValues
 {
-    public var showHUD: (HUDMessage) -> Void
+    public var showHUD: @MainActor (HUDMessage) -> Void
     {
         get { self[ShowHUDEnvironmentKey.self] }
         set { self[ShowHUDEnvironmentKey.self] = newValue }
@@ -13,6 +13,6 @@ extension EnvironmentValues
 
 private struct ShowHUDEnvironmentKey: EnvironmentKey
 {
-    static let defaultValue: (HUDMessage) -> Void = { _ in }
+    static let defaultValue: @MainActor (HUDMessage) -> Void = { _ in }
 }
 


### PR DESCRIPTION
Related:
- #2 

This PR improves `showHUD` thread-safety by adding `@MainActor` & `@Sendable` for HUD sender and `DialogButton` handlers. 