### PR TITLE
[Forms] Add `textFieldCell`

### DIFF
--- a/Examples/SherlockForms-Gallery.swiftpm/RootView.swift
+++ b/Examples/SherlockForms-Gallery.swiftpm/RootView.swift
@@ -56,6 +56,13 @@ struct RootView: View, SherlockView
                 // Built-in form cells (using `hstackCell` internally).
                 // See `FormCells` source directory for more info.
                 textCell(icon: icon, title: "User", value: username)
+                textFieldCell(icon: icon, title: "User (input)", value: $username) {
+                    $0
+                        // .keyboardType(.numberPad)
+                        // .textFieldStyle(RoundedBorderTextFieldStyle())
+                        .lineLimit(1)
+                        .disabled(false)
+                }
                 arrayPickerCell(icon: icon, title: "Language", selection: $languageSelection, values: Constant.languages)
                 casePickerCell(icon: icon, title: "Status", selection: $status)
                 toggleCell(icon: icon, title: "Low Power Mode", isOn: $isLowPowerOn)

--- a/Sources/SherlockForms/FormCells/TextFieldCell.swift
+++ b/Sources/SherlockForms/FormCells/TextFieldCell.swift
@@ -1,0 +1,76 @@
+import SwiftUI
+
+// MARK: - Constructors
+
+extension SherlockView
+{
+    @ViewBuilder
+    public func textFieldCell<Content>(
+        icon: Image? = nil,
+        title: String,
+        value: Binding<String>,
+        placeholder: String = "Input Value",
+        modify: @escaping (TextField<Text>) -> Content
+    ) -> TextFieldCell<Content>
+        where Content: View
+    {
+        TextFieldCell(
+            icon: icon,
+            title: title,
+            value: value,
+            placeholder: placeholder,
+            modify: modify,
+            canShowCell: canShowCell
+        )
+    }
+}
+
+// MARK: - TextFieldCell
+
+@MainActor
+public struct TextFieldCell<Content: View>: View
+{
+    private let icon: Image?
+    private let title: String
+    private let value: Binding<String>
+    private let placeholder: String
+    private let modify: (TextField<Text>) -> Content
+    private let canShowCell: @MainActor (_ keywords: [String]) -> Bool
+
+    @Environment(\.formCellCopyable)
+    private var isCopyable: Bool
+
+    internal init(
+        icon: Image? = nil,
+        title: String,
+        value: Binding<String>,
+        placeholder: String,
+        modify: @escaping (TextField<Text>) -> Content,
+        canShowCell: @MainActor @escaping (_ keywords: [String]) -> Bool = { _ in true }
+    )
+    {
+        self.icon = icon
+        self.title = title
+        self.value = value
+        self.placeholder = placeholder
+        self.modify = modify
+        self.canShowCell = canShowCell
+    }
+
+    public var body: some View
+    {
+        HStackCell(
+            keywords: [title, value.wrappedValue].compactMap { $0 },
+            canShowCell: canShowCell,
+            copyableKeyValue: isCopyable ? .init(key: title, value: value.wrappedValue) : nil
+        ) {
+            icon
+            Text(title)
+            Spacer(minLength: 16)
+            if let value = value {
+                modify(TextField(placeholder, text: value))
+                    .multilineTextAlignment(.trailing)
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds `textFieldCell`, a wrapper around `TextField` with taking `modify` argument as a customizable closure.

<img src=https://user-images.githubusercontent.com/138476/154493851-331f0fba-e589-4861-8b01-d143d2032d1a.PNG  width=300>

