### PR TITLE
[Forms] Add `touchesEnd` override to hide keyboard

### DIFF
--- a/Sources/SherlockForms/Internals/View+HideKeyboard.swift
+++ b/Sources/SherlockForms/Internals/View+HideKeyboard.swift
@@ -1,11 +1,25 @@
 import SwiftUI
 
-extension View
+@MainActor
+func hideKeyboard()
 {
-    @MainActor
-    func hideKeyboard()
+    let resign = #selector(UIResponder.resignFirstResponder)
+    UIApplication.shared.sendAction(resign, to: nil, from: nil, for: nil)
+}
+
+extension UIView
+{
+    // NOTE:
+    // `UIView.touchesEnded` extension works better than `form.onTapGesture`
+    // which causes some form UI to stop working.
+    // cf. https://developer.apple.com/forums/thread/127196
+    open override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?)
     {
-        let resign = #selector(UIResponder.resignFirstResponder)
-        UIApplication.shared.sendAction(resign, to: nil, from: nil, for: nil)
+        super.touchesEnded(touches, with: event)
+
+        let className = "\(self)"
+        if className.contains("CellHostingView") && className.contains("SwiftUI") {
+            hideKeyboard()
+        }
     }
 }


### PR DESCRIPTION
This PR adds a hack to override `touchesEnd` to hide currently presenting keyboard.

This hacky approach is discussed in:
https://developer.apple.com/forums/thread/127196

which works nicer compared to `tapGesture` on top of `form` as discussed in:
https://stackoverflow.com/questions/56491386/how-to-hide-keyboard-when-using-swiftui