### PR TITLE
[Forms] Add `textEditorCell`

### DIFF
--- a/Examples/SherlockForms-Gallery.swiftpm/RootView.swift
+++ b/Examples/SherlockForms-Gallery.swiftpm/RootView.swift
@@ -74,11 +74,16 @@ struct RootView: View, SherlockView
             }
 
             Section {
-                textFieldCell(icon: icon, title: "User (Editable)", value: $username) {
+                textFieldCell(icon: icon, title: "Editable", value: $username) {
                     $0
                         .multilineTextAlignment(.trailing)
                         .textFieldStyle(RoundedBorderTextFieldStyle())
-                        .disabled(false)
+                }
+
+                textEditorCell(icon: icon, title: "Multiline Editable", value: $username) {
+                    $0
+                        .multilineTextAlignment(.trailing)
+                        .frame(maxHeight: 100)
                 }
 
                 sliderCell(

--- a/Sources/SherlockForms/FormCells/TextEditorCell.swift
+++ b/Sources/SherlockForms/FormCells/TextEditorCell.swift
@@ -1,0 +1,75 @@
+import SwiftUI
+
+// MARK: - Constructors
+
+extension SherlockView
+{
+    @ViewBuilder
+    public func textEditorCell<Content>(
+        icon: Image? = nil,
+        title: String,
+        value: Binding<String>,
+        placeholder: String = "Input Value",
+        modify: @escaping (_ textEditor: AnyView) -> Content
+    ) -> TextEditorCell<Content>
+        where Content: View
+    {
+        TextEditorCell(
+            icon: icon,
+            title: title,
+            value: value,
+            placeholder: placeholder,
+            modify: modify,
+            canShowCell: canShowCell
+        )
+    }
+}
+
+// MARK: - TextEditorCell
+
+@MainActor
+public struct TextEditorCell<Content: View>: View
+{
+    private let icon: Image?
+    private let title: String
+    private let value: Binding<String>
+    private let placeholder: String
+    private let modify: (_ textEditor: AnyView) -> Content
+    private let canShowCell: @MainActor (_ keywords: [String]) -> Bool
+
+    @Environment(\.formCellCopyable)
+    private var isCopyable: Bool
+
+    internal init(
+        icon: Image? = nil,
+        title: String,
+        value: Binding<String>,
+        placeholder: String,
+        modify: @escaping (_ textEditor: AnyView) -> Content,
+        canShowCell: @MainActor @escaping (_ keywords: [String]) -> Bool = { _ in true }
+    )
+    {
+        self.icon = icon
+        self.title = title
+        self.value = value
+        self.placeholder = placeholder
+        self.modify = modify
+        self.canShowCell = canShowCell
+    }
+
+    public var body: some View
+    {
+        HStackCell(
+            keywords: [title, value.wrappedValue].compactMap { $0 },
+            canShowCell: canShowCell,
+            copyableKeyValue: isCopyable ? .init(key: title, value: value.wrappedValue) : nil
+        ) {
+            icon
+            Text(title)
+            Spacer(minLength: 16)
+            if let value = value {
+                modify(AnyView(TextEditorWithPlaceholder(placeholder, text: value)))
+            }
+        }
+    }
+}

--- a/Sources/SherlockForms/Internals/TextEditor.swift
+++ b/Sources/SherlockForms/Internals/TextEditor.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+
+struct TextEditorWithPlaceholder: View
+{
+    @Binding var text: String
+
+    private let placeholder: String
+
+    init(_ placeholder: String, text: Binding<String>)
+    {
+        self._text = text
+        self.placeholder = placeholder
+    }
+
+    var body: some View
+    {
+        ZStack {
+            if text.isEmpty {
+                Text(placeholder).opacity(0.25)
+                    .frame(maxWidth: .infinity, alignment: .trailing)
+            }
+            TextEditor(text: $text)
+                .padding(.horizontal, -4) // Remove TextEditor's extra padding.
+        }
+    }
+}


### PR DESCRIPTION
Related:
- #5 

This PR adds `textEditorCell`, multiline version of #5 with similar API.

<img src=https://user-images.githubusercontent.com/138476/154532313-45984d01-04f0-43eb-a8fb-8683f70e9cd7.png  width=300>

