### PR TITLE
[Forms] Allow empty title for `textFieldCell` & `textEditorCell`

### DIFF
--- a/Sources/SherlockForms/FormCells/TextEditorCell.swift
+++ b/Sources/SherlockForms/FormCells/TextEditorCell.swift
@@ -7,7 +7,7 @@ extension SherlockView
     @ViewBuilder
     public func textEditorCell<Content>(
         icon: Image? = nil,
-        title: String,
+        title: String? = nil,
         value: Binding<String>,
         placeholder: String = "Input Value",
         modify: @escaping (_ textEditor: AnyView) -> Content
@@ -31,7 +31,7 @@ extension SherlockView
 public struct TextEditorCell<Content: View>: View
 {
     private let icon: Image?
-    private let title: String
+    private let title: String?
     private let value: Binding<String>
     private let placeholder: String
     private let modify: (_ textEditor: AnyView) -> Content
@@ -42,7 +42,7 @@ public struct TextEditorCell<Content: View>: View
 
     internal init(
         icon: Image? = nil,
-        title: String,
+        title: String?,
         value: Binding<String>,
         placeholder: String,
         modify: @escaping (_ textEditor: AnyView) -> Content,
@@ -65,11 +65,11 @@ public struct TextEditorCell<Content: View>: View
             copyableKeyValue: isCopyable ? .init(key: title, value: value.wrappedValue) : nil
         ) {
             icon
-            Text(title)
-            Spacer(minLength: 16)
-            if let value = value {
-                modify(AnyView(TextEditorWithPlaceholder(placeholder, text: value)))
+            if let title = title {
+                Text(title)
+                Spacer(minLength: 16)
             }
+            modify(AnyView(TextEditorWithPlaceholder(placeholder, text: value)))
         }
     }
 }

--- a/Sources/SherlockForms/FormCells/TextFieldCell.swift
+++ b/Sources/SherlockForms/FormCells/TextFieldCell.swift
@@ -7,7 +7,7 @@ extension SherlockView
     @ViewBuilder
     public func textFieldCell<Content>(
         icon: Image? = nil,
-        title: String,
+        title: String? = nil,
         value: Binding<String>,
         placeholder: String = "Input Value",
         modify: @escaping (TextField<Text>) -> Content
@@ -31,7 +31,7 @@ extension SherlockView
 public struct TextFieldCell<Content: View>: View
 {
     private let icon: Image?
-    private let title: String
+    private let title: String?
     private let value: Binding<String>
     private let placeholder: String
     private let modify: (TextField<Text>) -> Content
@@ -42,7 +42,7 @@ public struct TextFieldCell<Content: View>: View
 
     internal init(
         icon: Image? = nil,
-        title: String,
+        title: String?,
         value: Binding<String>,
         placeholder: String,
         modify: @escaping (TextField<Text>) -> Content,
@@ -65,11 +65,11 @@ public struct TextFieldCell<Content: View>: View
             copyableKeyValue: isCopyable ? .init(key: title, value: value.wrappedValue) : nil
         ) {
             icon
-            Text(title)
-            Spacer(minLength: 16)
-            if let value = value {
-                modify(TextField(placeholder, text: value))
+            if let title = title {
+                Text(title)
+                Spacer(minLength: 16)
             }
+            modify(TextField(placeholder, text: value))
         }
     }
 }

--- a/Sources/SherlockForms/Internals/CopyableViewModifier.swift
+++ b/Sources/SherlockForms/Internals/CopyableViewModifier.swift
@@ -4,13 +4,13 @@ import SwiftUI
 @MainActor
 struct CopyableViewModifier: ViewModifier
 {
-    private let key: String
+    private let key: String?
     private let value: String?
 
     @Environment(\.showHUD)
     private var showHUD: @MainActor (HUDMessage) -> Void
 
-    init(key: String, value: String? = nil)
+    init(key: String? = nil, value: String? = nil)
     {
         self.key = key
         self.value = value
@@ -18,19 +18,25 @@ struct CopyableViewModifier: ViewModifier
 
     func body(content: Content) -> some View
     {
-        content.contextMenu {
-            if let value = value {
-                Button { copyString(key) } label: {
-                    Label("Copy Key", systemImage: "doc.on.doc")
-                }
+        if key == nil && value == nil {
+            content
+        }
+        else {
+            content.contextMenu {
+                if let key = key, let value = value {
+                    Button { copyString(key) } label: {
+                        Label("Copy Key", systemImage: "doc.on.doc")
+                    }
 
-                Button { copyString(value) } label: {
-                    Label("Copy Value", systemImage: "doc.on.doc")
+                    Button { copyString(value) } label: {
+                        Label("Copy Value", systemImage: "doc.on.doc")
+                    }
                 }
-            }
-            else {
-                Button { copyString(key) } label: {
-                    Label("Copy", systemImage: "doc.on.doc")
+                else {
+                    // NOTE: Should not reach empty string.
+                    Button { copyString(key ?? value ?? "") } label: {
+                        Label("Copy", systemImage: "doc.on.doc")
+                    }
                 }
             }
         }

--- a/Sources/SherlockForms/Types/FormCopyableKeyValue.swift
+++ b/Sources/SherlockForms/Types/FormCopyableKeyValue.swift
@@ -1,11 +1,11 @@
 /// "Copy Key" / "Copy Value" pair.
-/// - Note: If `value` is `nil`, `key` will be used as canonical "Copy".
+/// - Note: If `key` or `value` is `nil`, the remaining string will be used as canonical "Copy".
 public struct FormCellCopyableKeyValue
 {
-    public var key: String
+    public var key: String?
     public var value: String?
 
-    public init(key: String, value: String? = nil)
+    public init(key: String? = nil, value: String? = nil)
     {
         self.key = key
         self.value = value


### PR DESCRIPTION
Improvement for:
- #5 
- #7 

This PR allows empty title for `textFieldCell` & `textEditorCell` to use full-width text input.
By this change, context-menu's "Copy" functionality needs some fixes, and also resolved in this PR.

<img src=https://user-images.githubusercontent.com/138476/154535436-a7b4e3f0-eb5d-4475-bf66-535faf5abec2.png  width=300>