### PR TITLE
[Forms] Add `datePickerCell`

### DIFF
--- a/Examples/SherlockForms-Gallery.swiftpm/RootView.swift
+++ b/Examples/SherlockForms-Gallery.swiftpm/RootView.swift
@@ -29,6 +29,12 @@ struct RootView: View, SherlockView
     @AppStorage("low-power-mode")
     private var isLowPowerOn: Bool = false
 
+    @AppStorage("birthday")
+    private var birthday: SherlockDate = .init()
+
+    @AppStorage("alarm")
+    private var alarmDate: SherlockDate = .init()
+
     @AppStorage("speed")
     private var speed: Double = 1.0
 
@@ -99,6 +105,7 @@ struct RootView: View, SherlockView
                     maximumValueLabel: { Image(systemName: "hare") },
                     onEditingChanged: { print("onEditingChanged", $0) }
                 )
+
                 stepperCell(
                     icon: icon,
                     title: "Font Size",
@@ -107,6 +114,21 @@ struct RootView: View, SherlockView
                     step: 1,
                     maxFractionDigits: 0,
                     valueString: { "\($0) pt" }
+                )
+
+                datePickerCell(
+                    icon: icon,
+                    title: "Birthday",
+                    selection: $birthday.date,
+                    in: .distantPast ... Date(),
+                    displayedComponents: .date
+                )
+
+                datePickerCell(
+                    icon: icon,
+                    title: "Alarm",
+                    selection: $alarmDate.date,
+                    displayedComponents: [.hourAndMinute, .date]
                 )
             } header: {
                 Text("More form cells")

--- a/Sources/SherlockForms/FormCells/DatePickerCell.swift
+++ b/Sources/SherlockForms/FormCells/DatePickerCell.swift
@@ -1,0 +1,70 @@
+import SwiftUI
+
+// MARK: - Constructors
+
+extension SherlockView
+{
+    /// DatePicker cell.
+    @ViewBuilder
+    public func datePickerCell(
+        icon: Image? = nil,
+        title: String,
+        selection: Binding<Date>,
+        in bounds: ClosedRange<Date> = .distantPast ... .distantFuture,
+        displayedComponents: DatePickerComponents
+    ) -> some View
+    {
+        DatePickerCell(
+            icon: icon,
+            title: title,
+            selection: selection,
+            in: bounds,
+            displayedComponents: displayedComponents,
+            canShowCell: canShowCell
+        )
+    }
+}
+
+// MARK: - DatePickerCell
+
+public struct DatePickerCell: View
+{
+    private let icon: Image?
+    private let title: String
+    private let selection: Binding<Date>
+    private let bounds: ClosedRange<Date>
+    private let displayedComponents: DatePickerComponents
+    private let canShowCell: @MainActor (_ keywords: [String]) -> Bool
+
+    @Environment(\.formCellCopyable)
+    private var isCopyable: Bool
+
+    internal init(
+        icon: Image? = nil,
+        title: String,
+        selection: Binding<Date>,
+        in bounds: ClosedRange<Date>,
+        displayedComponents: DatePickerComponents,
+        canShowCell: @MainActor @escaping (_ keywords: [String]) -> Bool = { _ in true }
+    )
+    {
+        self.icon = icon
+        self.title = title
+        self.selection = selection
+        self.bounds = bounds
+        self.displayedComponents = displayedComponents
+        self.canShowCell = canShowCell
+    }
+
+    public var body: some View
+    {
+        HStackCell(
+            keywords: [title, "\(selection.wrappedValue)"],
+            canShowCell: canShowCell,
+            copyableKeyValue: isCopyable ? .init(key: title, value: "\(selection.wrappedValue)") : nil
+        ) {
+            icon
+            DatePicker(title, selection: selection, in: bounds, displayedComponents: displayedComponents)
+        }
+    }
+}

--- a/Sources/SherlockForms/Types/SherlockDate.swift
+++ b/Sources/SherlockForms/Types/SherlockDate.swift
@@ -1,0 +1,52 @@
+import SwiftUI
+
+/// `String`-representing `Date` wrapper, useful for storing as `UserDefaults` string via `@AppStorage`.
+public struct SherlockDate: RawRepresentable, Comparable
+{
+    public var date: Date
+
+    public init(_ date: Date = .init())
+    {
+        self.date = date
+    }
+
+    public init?(rawValue: String)
+    {
+        if let date = Self.formatter.date(from: rawValue) {
+            self.date = date
+        }
+        else {
+            return nil
+        }
+    }
+
+    public var rawValue: String
+    {
+        Self.formatter.string(from: date)
+    }
+
+    public static func == (l: Self, r: Self) -> Bool
+    {
+        l.date == r.date
+    }
+
+    public static func < (l: Self, r: Self) -> Bool
+    {
+        l.date < r.date
+    }
+
+    private static let formatter = ISO8601DateFormatter()
+}
+
+// MARK: - Binding
+
+extension Binding where Value == SherlockDate
+{
+    public var date: Binding<Date>
+    {
+        .init(
+            get: { wrappedValue.date },
+            set: { wrappedValue = SherlockDate($0) }
+        )
+    }
+}


### PR DESCRIPTION
This PR adds `datePickerCell` which wraps SwiftUI's `DatePicker`.

<img src=https://user-images.githubusercontent.com/138476/154793498-99ccdecf-0f71-4f51-8412-c2c79474dc15.png  width=300> <img src=https://user-images.githubusercontent.com/138476/154793507-b81b0c0c-8020-4146-8bf4-ba7415b53b61.png  width=300>
