### PR TITLE
[DebugForms] Refactor `UserDefaultsListView` to allow editing

### DIFF
--- a/Examples/SherlockForms-Gallery.swiftpm/Constant.swift
+++ b/Examples/SherlockForms-Gallery.swiftpm/Constant.swift
@@ -15,5 +15,17 @@ enum Constant
         case online = "Online"
         case away = "Away"
         case offline = "Offline"
+
+        init?(rawValue: String)
+        {
+            for case_ in Self.allCases {
+                if case_.rawValue.lowercased() == rawValue.lowercased() {
+                    self = case_
+                    return
+                }
+            }
+
+            return nil
+        }
     }
 }

--- a/Examples/SherlockForms-Gallery.swiftpm/MyApp.swift
+++ b/Examples/SherlockForms-Gallery.swiftpm/MyApp.swift
@@ -1,4 +1,7 @@
 import SwiftUI
+import SherlockDebugForms
+
+private let isDebug = false
 
 @main
 struct MyApp: App
@@ -7,7 +10,82 @@ struct MyApp: App
     {
         WindowGroup {
             NavigationView {
-                RootView()
+                if isDebug {
+                    // DEBUG: Shortcut presentation.
+                    UserDefaultsListView(
+                        editConfiguration: .init(
+                            boolKeys: Array(UserDefaultsBoolKey.allCases.map(\.rawValue)),
+                            stringKeys: Array(UserDefaultsStringKey.allCases.map(\.rawValue)),
+                            dateKeys: Array(UserDefaultsDateKey.allCases.map(\.rawValue)),
+                            intKeys: Array(UserDefaultsIntKey.allCases.map(\.rawValue)),
+                            doubleKeys: Array(UserDefaultsDoubleKey.allCases.map(\.rawValue))
+                        )
+                    )
+                }
+                else {
+                    RootView()
+                }
+            }
+            .onAppear {
+                guard isDebug else { return }
+
+                // DEBUG: Insert intial UserDefaults values.
+                UserDefaults.standard.set(
+                    "John Appleseed",
+                    forKey: UserDefaultsStringKey.username.rawValue
+                )
+
+                UserDefaults.standard.set(
+                    "john@example.com",
+                    forKey: UserDefaultsStringKey.email.rawValue
+                )
+
+                UserDefaults.standard.set(
+                    "admin",
+                    forKey: UserDefaultsStringKey.password.rawValue
+                )
+
+                // Index of `Constant.languages`.
+                UserDefaults.standard.set(
+                    0,
+                    forKey: UserDefaultsIntKey.languageSelection.rawValue
+                )
+
+                UserDefaults.standard.set(
+                    Constant.Status.away.rawValue,
+                    forKey: UserDefaultsStringKey.status.rawValue
+                )
+
+                UserDefaults.standard.set(
+                    true,
+                    forKey: UserDefaultsBoolKey.lowPowerMode.rawValue
+                )
+
+                UserDefaults.standard.set(
+                    1.0,
+                    forKey: UserDefaultsDoubleKey.speed.rawValue
+                )
+
+                UserDefaults.standard.set(
+                    12.0,
+                    forKey: UserDefaultsDoubleKey.fontSize.rawValue
+                )
+
+                UserDefaults.standard.set(
+                    Date().addingTimeInterval(-86400 * 365 * 20),
+                    forKey: UserDefaultsDateKey.birthday.rawValue
+                )
+
+                UserDefaults.standard.set(
+                    Date(),
+                    forKey: UserDefaultsDateKey.alarm.rawValue
+                )
+
+                // For testing long string in UserDefaults.
+                UserDefaults.standard.set(
+                    Array(repeating: Constant.loremIpsum, count: 10).joined(separator: "\n"),
+                    forKey: UserDefaultsStringKey.testLongUserDefaults.rawValue
+                )
             }
             .enableSherlockHUD(true)
         }

--- a/Examples/SherlockForms-Gallery.swiftpm/RootView.swift
+++ b/Examples/SherlockForms-Gallery.swiftpm/RootView.swift
@@ -10,38 +10,38 @@ struct RootView: View, SherlockView
     /// This is the only requirement to define as `@State`, and pass it to `SherlockForm`.
     @State public private(set) var searchText: String = ""
 
-    @AppStorage("username")
+    @AppStorage(UserDefaultsStringKey.username.rawValue)
     private var username: String = "John Appleseed"
 
-    @AppStorage("email")
+    @AppStorage(UserDefaultsStringKey.email.rawValue)
     private var email: String = "john@example.com"
 
-    @AppStorage("password")
+    @AppStorage(UserDefaultsStringKey.password.rawValue)
     private var password: String = "admin"
 
     /// Index of `Constant.languages`.
-    @AppStorage("language")
+    @AppStorage(UserDefaultsIntKey.languageSelection.rawValue)
     private var languageSelection: Int = 0
 
-    @AppStorage("status")
+    @AppStorage(UserDefaultsStringKey.status.rawValue)
     private var status = Constant.Status.online
 
-    @AppStorage("low-power-mode")
+    @AppStorage(UserDefaultsBoolKey.lowPowerMode.rawValue)
     private var isLowPowerOn: Bool = false
 
-    @AppStorage("birthday")
-    private var birthday: SherlockDate = .init()
-
-    @AppStorage("alarm")
-    private var alarmDate: SherlockDate = .init()
-
-    @AppStorage("speed")
+    @AppStorage(UserDefaultsDoubleKey.speed.rawValue)
     private var speed: Double = 1.0
 
-    @AppStorage("font-size")
+    @AppStorage(UserDefaultsDoubleKey.fontSize.rawValue)
     private var fontSize: Double = 10
 
-    @AppStorage("test-long-user-defaults")
+    @AppStorage(UserDefaultsDateKey.birthday.rawValue)
+    private var birthday: SherlockDate = .init()
+
+    @AppStorage(UserDefaultsDateKey.alarm.rawValue)
+    private var alarmDate: SherlockDate = .init()
+
+    @AppStorage(UserDefaultsStringKey.testLongUserDefaults.rawValue)
     private var stringForTestingLongUserDefault: String = ""
 
     /// - Note:
@@ -161,7 +161,17 @@ struct RootView: View, SherlockView
                 navigationLinkCell(
                     icon: icon,
                     title: "UserDefaults",
-                    destination: { UserDefaultsListView() }
+                    destination: {
+                        UserDefaultsListView(
+                            editConfiguration: .init(
+                                boolKeys: Array(UserDefaultsBoolKey.allCases.map(\.rawValue)),
+                                stringKeys: Array(UserDefaultsStringKey.allCases.map(\.rawValue)),
+                                dateKeys: Array(UserDefaultsDateKey.allCases.map(\.rawValue)),
+                                intKeys: Array(UserDefaultsIntKey.allCases.map(\.rawValue)),
+                                doubleKeys: Array(UserDefaultsDoubleKey.allCases.map(\.rawValue))
+                            )
+                        )
+                    }
                 )
                 navigationLinkCell(
                     icon: icon,
@@ -264,9 +274,6 @@ struct RootView: View, SherlockView
         // Use `formCellCopyable` here (as a wrapper of entire `SherlockForm`) to allow ALL `xxxCell`s to be copyable.
         // To Make each cell copyable one by one instead, call it as a wrapper of each form cell.
         .formCellCopyable(true)
-        .onAppear {
-            stringForTestingLongUserDefault = Array(repeating: Constant.loremIpsum, count: 10).joined(separator: "\n")
-        }
     }
 
     /// Customized form cell using `vstackCell`.

--- a/Examples/SherlockForms-Gallery.swiftpm/UserDefaultsKey.swift
+++ b/Examples/SherlockForms-Gallery.swiftpm/UserDefaultsKey.swift
@@ -1,0 +1,30 @@
+enum UserDefaultsBoolKey: String, CaseIterable
+{
+    case lowPowerMode = "low-power-mode"
+}
+
+enum UserDefaultsStringKey: String, CaseIterable
+{
+    case username = "username"
+    case email = "email"
+    case password = "password"
+    case status = "status"
+    case testLongUserDefaults = "test-long-user-defaults"
+}
+
+enum UserDefaultsIntKey: String, CaseIterable
+{
+    case languageSelection = "language"
+}
+
+enum UserDefaultsDoubleKey: String, CaseIterable
+{
+    case speed = "speed"
+    case fontSize = "font-size"
+}
+
+enum UserDefaultsDateKey: String, CaseIterable
+{
+    case birthday = "birthday"
+    case alarm = "alarm"
+}

--- a/Sources/SherlockDebugForms/Internals/UIView+CurrentFirstResponder.swift
+++ b/Sources/SherlockDebugForms/Internals/UIView+CurrentFirstResponder.swift
@@ -1,0 +1,24 @@
+import UIKit
+
+// Trying to find which text field is active ios
+// See https://stackoverflow.com/a/40352519/666371.
+extension UIView
+{
+    private enum Static
+    {
+        weak static var responder: UIView?
+    }
+
+    static func currentFirstResponder() -> UIView?
+    {
+        Static.responder = nil
+        UIApplication.shared.sendAction(#selector(UIView._trap), to: nil, from: nil, for: nil)
+        return Static.responder
+    }
+
+    @objc private func _trap()
+    {
+        Static.responder = self
+    }
+}
+

--- a/Sources/SherlockDebugForms/UserDefaultsListView.swift
+++ b/Sources/SherlockDebugForms/UserDefaultsListView.swift
@@ -2,12 +2,17 @@ import SwiftUI
 import SherlockForms
 
 /// UserDefaults viewer.
-/// - Todo: Make editable.
+///
+/// # Known issue
+/// - After presenting `DatePicker`'s popup, `showDetail` doesn' work properly (possibly due to SwiftUI bug).
 public struct UserDefaultsListView: View
 {
     @State private var searchText: String = ""
 
     private let userDefaults: UserDefaults
+
+    /// UserDefaults editable key-hints configuration to allow inline editing.
+    private let editConfiguration: EditConfiguration
 
     /// Custom list filtering.
     private let listFilter: ListFilter?
@@ -18,12 +23,14 @@ public struct UserDefaultsListView: View
     public init(
         userDefaults: UserDefaults = .standard,
         listFilter: ListFilter? = nil,
+        editConfiguration: EditConfiguration = .init(),
         maxCellHeight: CGFloat = 100,
         maxRecentlyUsedCount: Int = 3
     )
     {
         self.userDefaults = userDefaults
         self.listFilter = listFilter
+        self.editConfiguration = editConfiguration
         self.maxCellHeight = maxCellHeight
         self.maxRecentlyUsedCount = maxRecentlyUsedCount
     }
@@ -35,6 +42,7 @@ public struct UserDefaultsListView: View
                 searchText: searchText,
                 userDefaults: userDefaults,
                 listFilter: listFilter,
+                editConfiguration: editConfiguration,
                 maxCellHeight: maxCellHeight,
                 maxRecentlyUsedCount: maxRecentlyUsedCount
             )
@@ -43,13 +51,46 @@ public struct UserDefaultsListView: View
         .navigationBarTitleDisplayMode(.inline)
     }
 
+    // MARK: Inner Types
+
+    public typealias Key = String
+    public typealias Value = Any
+    public typealias KeyValue = (key: Key, value: Value)
+
     public typealias ListFilter = (_ searchText: String, _ keywords: [String]) -> Bool
+
+    /// UserDefaults editable key-hints configuration to allow inline editing.
+    public struct EditConfiguration
+    {
+        public var boolKeys: [Key]
+        public var stringKeys: [Key]
+        public var dateKeys: [Key]
+        public var intKeys: [Key]
+        public var doubleKeys: [Key]
+
+        public init(
+            boolKeys: [Key] = [],
+            stringKeys: [Key] = [],
+            dateKeys: [Key] = [],
+            intKeys: [Key] = [],
+            doubleKeys: [Key] = []
+        )
+        {
+            self.boolKeys = boolKeys
+            self.stringKeys = stringKeys
+            self.dateKeys = dateKeys
+            self.intKeys = intKeys
+            self.doubleKeys = doubleKeys
+        }
+    }
 }
 
 /// UserDefaults `Section`s, useful for presenting search results from ancestor screens.
 @MainActor
 public struct UserDefaultsListSectionsView: View, SherlockView
 {
+    @StateObject private var notifier: UserDefaultsNotifier = .init()
+
     public let searchText: String
 
     @State private var keyValues: [KeyValue] = []
@@ -60,6 +101,8 @@ public struct UserDefaultsListSectionsView: View, SherlockView
     @State private var presentingKey: String?
 
     private let userDefaults: UserDefaults
+
+    private let editConfiguration: EditConfiguration
 
     /// Custom list filtering.
     private let listFilter: ListFilter?
@@ -76,6 +119,7 @@ public struct UserDefaultsListSectionsView: View, SherlockView
         searchText: String,
         userDefaults: UserDefaults = .standard,
         listFilter: ListFilter? = nil,
+        editConfiguration: EditConfiguration = .init(),
         maxCellHeight: CGFloat = 100,
         maxRecentlyUsedCount: Int = 3,
         sectionHeader: @escaping (String) -> String = { $0 }
@@ -84,10 +128,10 @@ public struct UserDefaultsListSectionsView: View, SherlockView
         self.searchText = searchText
         self.userDefaults = userDefaults
 
-        self.keyValues = userDefaults.dictionaryRepresentation()
-            .sorted(by: { $0.0 < $1.0 })
+        self.keyValues = userDefaults.getKeyValues()
 
         self.listFilter = listFilter
+        self.editConfiguration = editConfiguration
         self.maxCellHeight = maxCellHeight
         self.maxRecentlyUsedCount = maxRecentlyUsedCount
         self.sectionHeader = sectionHeader
@@ -110,10 +154,14 @@ public struct UserDefaultsListSectionsView: View, SherlockView
                 sectionHeaderView(sectionHeader("All"))
             }
         }
+        .onReceive(notifier.objectWillChange) { _ in
+            keyValues = userDefaults.getKeyValues()
+        }
         .sheet(unwrapping: $presentingKey) { keyBinding in
             let key = keyBinding.wrappedValue
             if let index = keyValues.firstIndex(where: { $0.key == key }) {
-                UserDefaultsItemView(keyValue: $keyValues[index])
+                let value = keyValues[index].value
+                UserDefaultsItemView(key: key, value: value, userDefaults: userDefaults)
             }
         }
     }
@@ -139,32 +187,198 @@ public struct UserDefaultsListSectionsView: View, SherlockView
     private func keyValuesView(keyValues: [KeyValue]) -> some View
     {
         ForEach(keyValues, id: \.key) { key, value in
-            textCell(title: key, value: value)
-                .formCellContentModifier { cellContent in
-                    // WARNING:
-                    // `formCellContentModifier` is required for custom `contextMenu` attachment.
-                    // If below SwiftUI-method-chain is attached directly to `textCell` instead of `cellContent`,
-                    // malformed search result will appear.
-                    cellContent
-                        .frame(maxHeight: maxCellHeight)
-                        .contentShape(Rectangle()) // Improves tap for empty space.
-                        .onTapGesture {
-                            // copyAsString(value)
-                            showDetail(key: key)
-                        }
-                        .contextMenu {
-                            Button { copyAsString(key) } label: {
-                                Label("Copy Key", systemImage: "doc.on.doc")
-                            }
+            if editConfiguration.boolKeys.contains(key) {
+                if let bool = value as? Bool {
+                    boolValueCell(key: key, bool: bool)
+                }
+                else {
+                    defaultCell(key: key, value: value)
+                }
+            }
+            else if editConfiguration.stringKeys.contains(key) {
+                if let string = value as? String {
+                    stringValueCell(key: key, string: string)
+                }
+                else {
+                    defaultCell(key: key, value: value)
+                }
+            }
+            else if editConfiguration.dateKeys.contains(key) {
+                if let date_ = value as? Date,
+                   let date = SherlockDate(date_)
+                {
+                    dateValueCell(key: key, date: date)
+                }
+                else if let string = value as? String,
+                    let date = SherlockDate(rawValue: string)
+                {
+                    dateValueCell(key: key, date: date)
+                }
+                else {
+                    defaultCell(key: key, value: value)
+                }
+            }
+            else if editConfiguration.intKeys.contains(key) {
+                if let int = value as? Int {
+                    intValueCell(key: key, int: int)
+                }
+                else {
+                    defaultCell(key: key, value: value)
+                }
+            }
+            else if editConfiguration.doubleKeys.contains(key) {
+                if let double = value as? Double {
+                    doubleValueCell(key: key, double: double)
+                }
+                else {
+                    defaultCell(key: key, value: value)
+                }
+            }
+            else {
+                defaultCell(key: key, value: value)
+            }
+        }
+    }
 
-                            Button { copyAsString(value) } label: {
-                                Label("Copy Value", systemImage: "doc.on.doc")
-                            }
+    @ViewBuilder
+    private func boolValueCell(key: Key, bool: Bool) -> some View
+    {
+        toggleCell(title: key, isOn: Binding(get: { bool }, set: { newValue in
+            userDefaults.set(newValue, forKey: key)
+            insertRecentlyUsedKey(key)
+            self.keyValues = userDefaults.getKeyValues()
+        }))
+            .formCellContentModifier(contextMenuModifier(key: key, value: bool))
+    }
 
-                            Button { deleteKey(key) } label: {
-                                Label("Delete", systemImage: "trash")
-                            }
-                        }
+    @ViewBuilder
+    private func stringValueCell(key: Key, string: String) -> some View
+    {
+        textFieldCell(
+            title: key,
+            value: Binding(get: { string }, set: { newValue in
+                userDefaults.set(newValue, forKey: key)
+                insertRecentlyUsedKey(key)
+                self.keyValues = userDefaults.getKeyValues()
+            }),
+            modify: {
+                $0
+                    .onTapGesture { /* Don't let wrapper view to steal this tap */ }
+                    .frame(minWidth: 100, maxWidth: 200)
+                    .multilineTextAlignment(.trailing)
+                    .lineLimit(4)
+                    .keyboardType(.default)
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+            }
+        )
+            .formCellContentModifier(contextMenuModifier(key: key, value: string))
+    }
+
+    @ViewBuilder
+    private func dateValueCell(key: Key, date: SherlockDate) -> some View
+    {
+        datePickerCell(
+            title: key,
+            selection: Binding(get: { date.date }, set: { newValue in
+                let date = SherlockDate(newValue)
+
+                userDefaults.set(date.rawValue, forKey: key)
+                insertRecentlyUsedKey(key)
+                self.keyValues = userDefaults.getKeyValues()
+            }),
+            displayedComponents: [.date, .hourAndMinute]
+        )
+            .formCellContentModifier(contextMenuModifier(key: key, value: date.rawValue))
+    }
+
+    @ViewBuilder
+    private func intValueCell(key: Key, int: Int) -> some View
+    {
+        textFieldCell(
+            title: key,
+            value: Binding(get: { "\(int)" }, set: { newValue in
+                guard let int = Int(newValue) else { return }
+
+                userDefaults.set(int, forKey: key)
+                insertRecentlyUsedKey(key)
+                self.keyValues = userDefaults.getKeyValues()
+            }),
+            modify: {
+                $0
+                    .onTapGesture { /* Don't let wrapper view to steal this tap */ }
+                    .frame(minWidth: 100, maxWidth: 200)
+                    .multilineTextAlignment(.trailing)
+                    .keyboardType(.numberPad)
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+            }
+        )
+            .formCellContentModifier(contextMenuModifier(key: key, value: int))
+    }
+
+    @ViewBuilder
+    private func doubleValueCell(key: Key, double: Double) -> some View
+    {
+        textFieldCell(
+            title: key,
+            value: Binding(get: { "\(double)" }, set: { newValue in
+                guard let double = Double(newValue) else { return }
+
+                userDefaults.set(double, forKey: key)
+                insertRecentlyUsedKey(key)
+                self.keyValues = userDefaults.getKeyValues()
+            }),
+            modify: {
+                $0
+                    .onTapGesture { /* Don't let wrapper view to steal this tap */ }
+                    .frame(minWidth: 100, maxWidth: 200)
+                    .multilineTextAlignment(.trailing)
+                    .keyboardType(.decimalPad)
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+            }
+        )
+            .formCellContentModifier(contextMenuModifier(key: key, value: double))
+    }
+
+    @ViewBuilder
+    private func defaultCell(key: Key, value: Value) -> some View
+    {
+        textCell(title: key, value: value)
+            .formCellContentModifier(contextMenuModifier(key: key, value: value))
+    }
+
+    private func contextMenuModifier(key: Key, value: Value) -> AnyViewModifier {
+        AnyViewModifier { content in
+            // WARNING:
+            // `formCellContentModifier` is required for custom `contextMenu` attachment.
+            // If below SwiftUI-method-chain is attached directly to `textCell` instead of `cellContent`,
+            // malformed search result will appear.
+            content
+                .frame(maxWidth: .infinity, maxHeight: maxCellHeight)
+                .contentShape(Rectangle()) // Improves tap for empty space.
+                .onTapGesture {
+                    if let firstResponder = UIView.currentFirstResponder() {
+                        firstResponder.resignFirstResponder()
+                    }
+                    else {
+                        showDetail(key: key)
+                    }
+                }
+                .contextMenu {
+                    Button { copyAsString(key) } label: {
+                        Label("Copy Key", systemImage: "doc.on.doc")
+                    }
+
+                    Button { copyAsString(value) } label: {
+                        Label("Copy Value", systemImage: "doc.on.doc")
+                    }
+
+                    Button { showDetail(key: key) } label: {
+                        Label("Show Detail", systemImage: "doc.text.magnifyingglass")
+                    }
+
+                    Button { deleteKey(key) } label: {
+                        Label("Delete", systemImage: "trash")
+                    }
                 }
         }
     }
@@ -225,22 +439,26 @@ public struct UserDefaultsListSectionsView: View, SherlockView
             try await Task.sleep(nanoseconds: 300_000_000)
 
             // Then, update `recentlyUsedKeys`.
-            if maxRecentlyUsedCount > 0 {
-                await MainActor.run {
-                    var keys = recentlyUsedKeys.strings
-                    keys.removeAll(where: { $0 == key })
-                    keys = Array(keys.suffix(maxRecentlyUsedCount - 1))
-                    keys.append(key)
-                    recentlyUsedKeys.strings = keys
-                }
-            }
+            insertRecentlyUsedKey(key)
         }
     }
 
-    public typealias Key = String
-    public typealias Value = Any
-    public typealias KeyValue = (key: Key, value: Value)
+    private func insertRecentlyUsedKey(_ key: String)
+    {
+        guard maxRecentlyUsedCount > 0 else { return }
+
+        var keys = recentlyUsedKeys.strings
+        keys.removeAll(where: { $0 == key })
+        keys = Array(keys.suffix(maxRecentlyUsedCount - 1))
+        keys.append(key)
+        recentlyUsedKeys.strings = keys
+    }
+
+    public typealias Key = UserDefaultsListView.Key
+    public typealias Value = UserDefaultsListView.Value
+    public typealias KeyValue = UserDefaultsListView.KeyValue
     public typealias ListFilter = UserDefaultsListView.ListFilter
+    public typealias EditConfiguration = UserDefaultsListView.EditConfiguration
 }
 
 // MARK: - Strings
@@ -272,4 +490,23 @@ extension Strings: RawRepresentable
         }
         return result
     }
+}
+
+// MARK: - Private
+
+extension UserDefaults
+{
+    func getKeyValues() -> [UserDefaultsListView.KeyValue]
+    {
+        dictionaryRepresentation()
+            .sorted(by: { $0.0 < $1.0 })
+    }
+}
+
+private final class UserDefaultsNotifier : ObservableObject
+{
+    let objectWillChange = NotificationCenter.default
+        .publisher(for: UserDefaults.didChangeNotification, object: nil)
+
+    init() {}
 }

--- a/Sources/SherlockForms/FormCells/ArrayPickerCell.swift
+++ b/Sources/SherlockForms/FormCells/ArrayPickerCell.swift
@@ -53,7 +53,12 @@ public struct ArrayPickerCell<Value>: View
         HStackCell(
             keywords: [title],
             canShowCell: canShowCell,
-            copyableKeyValue: isCopyable ? .init(key: title, value: "\(values[selection.wrappedValue])") : nil
+            copyableKeyValue: isCopyable
+                ? .init(
+                    key: title,
+                    value: values[safe: selection.wrappedValue].map { "\($0)" }
+                )
+                : nil
         ) {
             icon
             Picker(selection: selection, label: Text(title)) {

--- a/Sources/SherlockForms/FormCells/TextEditorCell.swift
+++ b/Sources/SherlockForms/FormCells/TextEditorCell.swift
@@ -23,6 +23,23 @@ extension SherlockView
             canShowCell: canShowCell
         )
     }
+
+    @ViewBuilder
+    public func textEditorCell(
+        icon: Image? = nil,
+        title: String? = nil,
+        value: Binding<String>,
+        placeholder: String = "Input Value"
+    ) -> TextEditorCell<AnyView>
+    {
+        textEditorCell(
+            icon: icon,
+            title: title,
+            value: value,
+            placeholder: placeholder,
+            modify: { $0 }
+        )
+    }
 }
 
 // MARK: - TextEditorCell

--- a/Sources/SherlockForms/FormCells/ToggleCell.swift
+++ b/Sources/SherlockForms/FormCells/ToggleCell.swift
@@ -59,6 +59,7 @@ public struct ToggleCell: View
             Toggle(isOn: isOn) {
                 EmptyView()
             }
+            .onTapGesture { /* Don't let wrapper view to steal this tap */ }
         }
     }
 }

--- a/Sources/SherlockForms/Internals/Collection+Safe.swift
+++ b/Sources/SherlockForms/Internals/Collection+Safe.swift
@@ -1,0 +1,18 @@
+extension Collection
+{
+    subscript (safe index: Index) -> Iterator.Element?
+    {
+        return self.startIndex <= index && index < self.endIndex
+            ? self[index]
+            : nil
+    }
+
+    subscript <R: RangeExpression>(safe range: R) -> SubSequence?
+        where R.Bound == Index
+    {
+        let r = range.relative(to: self)
+        return r.lowerBound >= self.startIndex && r.upperBound <= self.endIndex
+            ? self[range]
+            : nil
+    }
+}

--- a/Sources/SherlockForms/Internals/TextEditor.swift
+++ b/Sources/SherlockForms/Internals/TextEditor.swift
@@ -6,7 +6,13 @@ struct TextEditorWithPlaceholder: View
 
     private let placeholder: String
 
-    init(_ placeholder: String, text: Binding<String>)
+    @Environment(\.multilineTextAlignment)
+    private var _placeholderAlignment: TextAlignment
+
+    init(
+        _ placeholder: String,
+        text: Binding<String>
+    )
     {
         self._text = text
         self.placeholder = placeholder
@@ -16,11 +22,25 @@ struct TextEditorWithPlaceholder: View
     {
         ZStack {
             if text.isEmpty {
-                Text(placeholder).opacity(0.25)
-                    .frame(maxWidth: .infinity, alignment: .trailing)
+                Text(placeholder)
+                    .opacity(0.25)
+                    .frame(maxWidth: .infinity, alignment: placeholderAlignment)
             }
             TextEditor(text: $text)
                 .padding(.horizontal, -4) // Remove TextEditor's extra padding.
+        }
+        .frame(maxWidth: .infinity, alignment: .trailing)
+    }
+
+    private var placeholderAlignment: Alignment
+    {
+        switch _placeholderAlignment {
+        case .leading:
+            return .leading
+        case .center:
+            return .center
+        case .trailing:
+            return .trailing
         }
     }
 }


### PR DESCRIPTION
This PR refactors DebugForms's `UserDefaultsListView` to allow value-editing.

<img src=https://user-images.githubusercontent.com/138476/154799107-d8bb13a7-15c1-459f-8932-7e81e0020420.PNG  width=300> <img src=https://user-images.githubusercontent.com/138476/154799113-0fcac372-d2bd-4355-8490-1651f3b4d940.PNG  width=300>

### Known issue

- After presenting `DatePicker`'s popup, `showDetail` doesn't work properly (possibly due to SwiftUI bug).

