### PR TITLE
[Forms] Add `AsyncArrayPickerCell`

### DIFF
--- a/Examples/SherlockForms-Gallery.swiftpm/RootView.swift
+++ b/Examples/SherlockForms-Gallery.swiftpm/RootView.swift
@@ -79,6 +79,7 @@ struct RootView: View, SherlockView
                 }
             }
 
+            // More form cells
             Section {
                 textFieldCell(icon: icon, title: "Editable", value: $username) {
                     $0
@@ -91,6 +92,24 @@ struct RootView: View, SherlockView
                         .multilineTextAlignment(.trailing)
                         .frame(maxHeight: 100)
                 }
+
+                arrayPickerCell(
+                    icon: icon,
+                    title: "Async Picker",
+                    selection: $languageSelection,
+                    accessory: {
+                        Text("Default")
+                            .foregroundColor(.gray)
+                        Spacer().frame(width: 8)
+                        ProgressView()
+                    },
+                    action: {
+                        // Simulating async work...
+                        try await Task.sleep(nanoseconds: 3_000_000_000)
+                        return Constant.languages
+                    },
+                    valueType: String.self
+                )
 
                 sliderCell(
                     icon: icon,

--- a/Sources/SherlockForms/FormCells/ArrayPickerCell.swift
+++ b/Sources/SherlockForms/FormCells/ArrayPickerCell.swift
@@ -12,9 +12,37 @@ extension SherlockView
         selection: Binding<Int>,
         values: [Value]
     ) -> some View
-        where Value: Hashable
     {
         ArrayPickerCell(icon: icon, title: title, selection: selection, values: values, canShowCell: canShowCell)
+    }
+
+    /// Async-picker cell with `selection: Binding<Int>` from `action`-fetched values.
+    ///
+    /// 1. Before `action`: Shows `title` and `accessory`
+    /// 2. After `action`: Shows ``ArrayPickerCell`` with values being fetched by `action`.
+    ///
+    /// # Known issue
+    /// When this cell appears at middle of the form after scroll, and `accessory` contains `ProgressView`,
+    /// it may not animate correctly, possibly due to SwiftUI bug.
+    @ViewBuilder
+    public func arrayPickerCell<Value, Accessory>(
+        icon: Image? = nil,
+        title: String,
+        selection: Binding<Int>,
+        @ViewBuilder accessory: @escaping () -> Accessory,
+        action: @Sendable @escaping () async throws -> [Value],
+        valueType: Value.Type = Value.self
+    ) -> some View
+        where Accessory: View
+    {
+        AsyncArrayPickerCell(
+            icon: icon,
+            title: title,
+            selection: selection,
+            accessory: accessory,
+            action: action,
+            canShowCell: canShowCell
+        )
     }
 }
 
@@ -22,7 +50,6 @@ extension SherlockView
 
 @MainActor
 public struct ArrayPickerCell<Value>: View
-    where Value: Hashable
 {
     private let icon: Image?
     private let title: String
@@ -60,12 +87,76 @@ public struct ArrayPickerCell<Value>: View
                 )
                 : nil
         ) {
-            icon
-            Picker(selection: selection, label: Text(title)) {
-                ForEach(0 ..< values.count) { i in
-                    Text("\(String(describing: values[i]))")
+            ZStack(alignment: .trailing) {
+                Group {
+                    icon
+
+                    Picker(selection: selection) {
+                        ForEach(0 ..< values.count) { i in
+                            Text("\(String(describing: values[i]))")
+                        }
+                    } label: {
+                        Text(title)
+                    }
                 }
+
+                ProgressView()
+                    .padding(.trailing, 16)
+                    .opacity(values.isEmpty ? 1 : 0)
             }
+        }
+    }
+}
+
+// MARK: - AsyncArrayPickerCell
+
+@MainActor
+public struct AsyncArrayPickerCell<Value, Accessory>: View
+    where Accessory: View
+{
+    private let icon: Image?
+    private let title: String
+    private let selection: Binding<Int>
+    private let accessory: () -> AnyView
+    private let action: () async throws -> [Value]
+    private let canShowCell: @MainActor (_ keywords: [String]) -> Bool
+
+    @State private var values: [Value] = []
+
+    @Environment(\.formCellCopyable)
+    private var isCopyable: Bool
+
+    internal init(
+        icon: Image? = nil,
+        title: String,
+        selection: Binding<Int>,
+        @ViewBuilder accessory: @escaping () -> Accessory,
+        action: @Sendable @escaping () async throws -> [Value],
+        canShowCell: @MainActor @escaping (_ keywords: [String]) -> Bool = { _ in true }
+    )
+    {
+        self.icon = icon
+        self.title = title
+        self.selection = selection
+        self.accessory = { AnyView(accessory()) }
+        self.action = action
+        self.canShowCell = canShowCell
+    }
+
+    public var body: some View
+    {
+        if values.isEmpty {
+            TextCell(icon: icon, title: title, value: nil, accessory: accessory, canShowCell: canShowCell)
+                .onAppear {
+                    guard values.isEmpty else { return }
+
+                    Task {
+                        values = try await action()
+                    }
+                }
+        }
+        else {
+            ArrayPickerCell(icon: icon, title: title, selection: selection, values: values, canShowCell: canShowCell)
         }
     }
 }


### PR DESCRIPTION
This PR adds `AsyncArrayPickerCell` for async-loading and then shows `arrayPickerCell`.

https://user-images.githubusercontent.com/138476/154999950-79b28206-6c9c-41b1-b732-1d60e56b11e8.mp4

### Known issue
When this cell appears at middle of the form after scroll, and `accessory` contains `ProgressView`,
it may not animate correctly, possibly due to SwiftUI bug.

