### PR TITLE
[Forms] Improve `arrayPickerCell`'s `selection` by using `Hashable` value rather than `Int`

### DIFF
--- a/Examples/SherlockForms-Gallery.swiftpm/MyApp.swift
+++ b/Examples/SherlockForms-Gallery.swiftpm/MyApp.swift
@@ -45,10 +45,15 @@ struct MyApp: App
                     forKey: UserDefaultsStringKey.password.rawValue
                 )
 
+                UserDefaults.standard.set(
+                    Constant.languages[0],
+                    forKey: UserDefaultsStringKey.languageSelection.rawValue
+                )
+
                 // Index of `Constant.languages`.
                 UserDefaults.standard.set(
                     0,
-                    forKey: UserDefaultsIntKey.languageSelection.rawValue
+                    forKey: UserDefaultsIntKey.languageIntSelection.rawValue
                 )
 
                 UserDefaults.standard.set(

--- a/Examples/SherlockForms-Gallery.swiftpm/RootView.swift
+++ b/Examples/SherlockForms-Gallery.swiftpm/RootView.swift
@@ -19,9 +19,12 @@ struct RootView: View, SherlockView
     @AppStorage(UserDefaultsStringKey.password.rawValue)
     private var password: String = "admin"
 
+    @AppStorage(UserDefaultsStringKey.languageSelection.rawValue)
+    private var languageSelection: String = Constant.languages[0]
+
     /// Index of `Constant.languages`.
-    @AppStorage(UserDefaultsIntKey.languageSelection.rawValue)
-    private var languageSelection: Int = 0
+    @AppStorage(UserDefaultsIntKey.languageIntSelection.rawValue)
+    private var languageIntSelection: Int = 0
 
     @AppStorage(UserDefaultsStringKey.status.rawValue)
     private var status = Constant.Status.online
@@ -92,6 +95,20 @@ struct RootView: View, SherlockView
                         .multilineTextAlignment(.trailing)
                         .frame(maxHeight: 100)
                 }
+
+                // Array picker cell that uses `languageIntSelection` (index) as state.
+                arrayPickerCell(
+                    icon: icon,
+                    title: "Int Picker",
+                    selection: Binding(
+                        get: { Constant.languages[languageIntSelection] },
+                        set: { newValue in
+                            guard let index = Constant.languages.firstIndex(of: newValue) else { return }
+                            languageIntSelection = index
+                        }
+                    ),
+                    values: Constant.languages
+                )
 
                 arrayPickerCell(
                     icon: icon,

--- a/Examples/SherlockForms-Gallery.swiftpm/UserDefaultsKey.swift
+++ b/Examples/SherlockForms-Gallery.swiftpm/UserDefaultsKey.swift
@@ -9,12 +9,13 @@ enum UserDefaultsStringKey: String, CaseIterable
     case email = "email"
     case password = "password"
     case status = "status"
+    case languageSelection = "language"
     case testLongUserDefaults = "test-long-user-defaults"
 }
 
 enum UserDefaultsIntKey: String, CaseIterable
 {
-    case languageSelection = "language"
+    case languageIntSelection = "language-int"
 }
 
 enum UserDefaultsDoubleKey: String, CaseIterable


### PR DESCRIPTION
**Note: Breaking change.**

This PR improves `arrayPickerCell`'s `selection` by using `Hashable` value rather than `Int`.

To work as existing `Int`-based approach, developer will need mutual `Binding` conversions between `Int` and `Value` as shown in this PR's example.