### PR TITLE
[Forms] Add `FormCellIconWidthEnvironmentKey`

### DIFF
--- a/Examples/SherlockForms-Gallery.swiftpm/RootView.swift
+++ b/Examples/SherlockForms-Gallery.swiftpm/RootView.swift
@@ -55,9 +55,6 @@ struct RootView: View, SherlockView
 
     var body: some View
     {
-        let icon: Image? = nil
-        // let icon: Image? = Image(systemName: "applelogo")
-
         // NOTE:
         // `SherlockForm` and `xxxCell` is where all the search magic is happening!
         // Just treat `SherlockForm` as a normal `Form`, and use `Section` and plain SwiftUI views accordingly.
@@ -310,6 +307,14 @@ struct RootView: View, SherlockView
         // Use `formCellCopyable` here (as a wrapper of entire `SherlockForm`) to allow ALL `xxxCell`s to be copyable.
         // To Make each cell copyable one by one instead, call it as a wrapper of each form cell.
         .formCellCopyable(true)
+        // For aligning icons and texts horizontally.
+        .formCellIconWidth(30)
+    }
+
+    private var icon: Image?
+    {
+        // return nil
+        return Image(systemName: ["applelogo", "iphone", "macwindow"].randomElement()!)
     }
 
     /// Customized form cell using `vstackCell`.

--- a/Sources/SherlockForms/Environment/FormCellIconWidthEnvironmentKey.swift
+++ b/Sources/SherlockForms/Environment/FormCellIconWidthEnvironmentKey.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+
+extension View
+{
+    @MainActor
+    public func formCellIconWidth(_ iconWidth: CGFloat?) -> some View
+    {
+        environment(\.formCellIconWidth, iconWidth)
+    }
+}
+
+// MARK: - FormCellIconWidthEnvironmentKey
+
+private struct FormCellIconWidthEnvironmentKey: EnvironmentKey
+{
+    static let defaultValue: CGFloat? = nil
+}
+
+extension EnvironmentValues
+{
+    var formCellIconWidth: CGFloat?
+    {
+        get { self[FormCellIconWidthEnvironmentKey.self] }
+        set { self[FormCellIconWidthEnvironmentKey.self] = newValue }
+    }
+}

--- a/Sources/SherlockForms/FormCells/ArrayPickerCell.swift
+++ b/Sources/SherlockForms/FormCells/ArrayPickerCell.swift
@@ -62,6 +62,9 @@ public struct ArrayPickerCell<Value>: View
     @Environment(\.formCellCopyable)
     private var isCopyable: Bool
 
+    @Environment(\.formCellIconWidth)
+    private var iconWidth: CGFloat?
+
     internal init(
         icon: Image? = nil,
         title: String,
@@ -89,7 +92,7 @@ public struct ArrayPickerCell<Value>: View
                 )
                 : nil
         ) {
-            icon
+            icon.frame(minWidth: iconWidth, maxWidth: iconWidth)
 
             Picker(selection: selection) {
                 ForEach(0 ..< values.count) { i in
@@ -130,6 +133,9 @@ public struct AsyncArrayPickerCell<Value, Accessory>: View
 
     @Environment(\.formCellCopyable)
     private var isCopyable: Bool
+
+    @Environment(\.formCellIconWidth)
+    private var iconWidth: CGFloat?
 
     internal init(
         icon: Image? = nil,

--- a/Sources/SherlockForms/FormCells/ButtonCell.swift
+++ b/Sources/SherlockForms/FormCells/ButtonCell.swift
@@ -36,6 +36,9 @@ public struct ButtonCell: View
     @Environment(\.formCellCopyable)
     private var isCopyable: Bool
 
+    @Environment(\.formCellIconWidth)
+    private var iconWidth: CGFloat?
+
     internal init(
         icon: Image? = nil,
         title: String,
@@ -56,7 +59,7 @@ public struct ButtonCell: View
             canShowCell: canShowCell,
             copyableKeyValue: isCopyable ? .init(key: title) : nil
         ) {
-            icon
+            icon.frame(minWidth: iconWidth, maxWidth: iconWidth)
             Button(title, action: {
                 currentTask?.cancel()
                 currentTask = Task {

--- a/Sources/SherlockForms/FormCells/ButtonDialogCell.swift
+++ b/Sources/SherlockForms/FormCells/ButtonDialogCell.swift
@@ -43,6 +43,9 @@ public struct ButtonDialogCell: View
     @Environment(\.formCellCopyable)
     private var isCopyable: Bool
 
+    @Environment(\.formCellIconWidth)
+    private var iconWidth: CGFloat?
+
     internal init(
         icon: Image? = nil,
         title: String,
@@ -68,7 +71,7 @@ public struct ButtonDialogCell: View
             copyableKeyValue: isCopyable ? .init(key: title) : nil
         ) {
             Group {
-                icon
+                icon.frame(minWidth: iconWidth, maxWidth: iconWidth)
                 Button(title, action: {
                     currentTask?.cancel()
                     isLoading = false

--- a/Sources/SherlockForms/FormCells/CasePickerCell.swift
+++ b/Sources/SherlockForms/FormCells/CasePickerCell.swift
@@ -42,6 +42,9 @@ public struct CasePickerCell<Value>: View
     @Environment(\.formCellCopyable)
     private var isCopyable: Bool
 
+    @Environment(\.formCellIconWidth)
+    private var iconWidth: CGFloat?
+
     internal init(
         icon: Image? = nil,
         title: String,
@@ -62,7 +65,7 @@ public struct CasePickerCell<Value>: View
             canShowCell: canShowCell,
             copyableKeyValue: isCopyable ? .init(key: title, value: "\(selection.wrappedValue)") : nil
         ) {
-            icon
+            icon.frame(minWidth: iconWidth, maxWidth: iconWidth)
             Picker(selection: selection, label: Text(title)) {
                 ForEach(Array(Value.allCases), id: \.self) { value in
                     Text("\(String(describing: value))")
@@ -86,6 +89,9 @@ public struct RawRepresentableCasePickerCell<Value>: View
     @Environment(\.formCellCopyable)
     private var isCopyable: Bool
 
+    @Environment(\.formCellIconWidth)
+    private var iconWidth: CGFloat?
+
     internal init(
         icon: Image? = nil,
         title: String,
@@ -108,7 +114,7 @@ public struct RawRepresentableCasePickerCell<Value>: View
             canShowCell: canShowCell,
             copyableKeyValue: isCopyable ? .init(key: title, value: "\(rawValue)") : nil
         ) {
-            icon
+            icon.frame(minWidth: iconWidth, maxWidth: iconWidth)
             Picker(selection: selection, label: Text(title)) {
                 ForEach(Array(Value.allCases), id: \.self) { value in
                     Text("\(String(describing: value.rawValue))")

--- a/Sources/SherlockForms/FormCells/DatePickerCell.swift
+++ b/Sources/SherlockForms/FormCells/DatePickerCell.swift
@@ -39,6 +39,9 @@ public struct DatePickerCell: View
     @Environment(\.formCellCopyable)
     private var isCopyable: Bool
 
+    @Environment(\.formCellIconWidth)
+    private var iconWidth: CGFloat?
+
     internal init(
         icon: Image? = nil,
         title: String,
@@ -63,7 +66,7 @@ public struct DatePickerCell: View
             canShowCell: canShowCell,
             copyableKeyValue: isCopyable ? .init(key: title, value: "\(SherlockDate(selection.wrappedValue).rawValue)") : nil
         ) {
-            icon
+            icon.frame(minWidth: iconWidth, maxWidth: iconWidth)
             DatePicker(title, selection: selection, in: bounds, displayedComponents: displayedComponents)
         }
     }

--- a/Sources/SherlockForms/FormCells/NavigationLinkCell.swift
+++ b/Sources/SherlockForms/FormCells/NavigationLinkCell.swift
@@ -33,6 +33,9 @@ public struct NavigationLinkCell<Destination>: View
     @Environment(\.formCellContentModifier)
     private var formCellContentModifier: AnyViewModifier
 
+    @Environment(\.formCellIconWidth)
+    private var iconWidth: CGFloat?
+
     internal init(
         icon: Image? = nil,
         title: String,
@@ -57,7 +60,7 @@ public struct NavigationLinkCell<Destination>: View
     private var _body: some View
     {
         let link = NavigationLink(destination: LazyView(destination()), label: {
-            icon
+            icon.frame(minWidth: iconWidth, maxWidth: iconWidth)
             Text(title)
         })
             .modifier(formCellContentModifier)

--- a/Sources/SherlockForms/FormCells/SliderCell.swift
+++ b/Sources/SherlockForms/FormCells/SliderCell.swift
@@ -90,6 +90,9 @@ public struct SliderCell<Label, ValueLabel>: View
     @Environment(\.formCellCopyable)
     private var isCopyable: Bool
 
+    @Environment(\.formCellIconWidth)
+    private var iconWidth: CGFloat?
+
     internal init<Value>(
         icon: Image? = nil,
         title: String,
@@ -135,7 +138,7 @@ public struct SliderCell<Label, ValueLabel>: View
             copyableKeyValue: isCopyable ? .init(key: title, value: valueString_) : nil
         ) {
             HStack {
-                icon
+                icon.frame(minWidth: iconWidth, maxWidth: iconWidth)
                 Text(title)
                 Spacer()
                 Text(valueString_)

--- a/Sources/SherlockForms/FormCells/StepperCell.swift
+++ b/Sources/SherlockForms/FormCells/StepperCell.swift
@@ -45,6 +45,9 @@ public struct StepperCell: View
     @Environment(\.formCellCopyable)
     private var isCopyable: Bool
 
+    @Environment(\.formCellIconWidth)
+    private var iconWidth: CGFloat?
+
     internal init(
         icon: Image? = nil,
         title: String,
@@ -75,7 +78,7 @@ public struct StepperCell: View
             canShowCell: canShowCell,
             copyableKeyValue: isCopyable ? .init(key: title, value: valueString_) : nil
         ) {
-            icon
+            icon.frame(minWidth: iconWidth, maxWidth: iconWidth)
             Text(title)
             Spacer()
 

--- a/Sources/SherlockForms/FormCells/TextCell.swift
+++ b/Sources/SherlockForms/FormCells/TextCell.swift
@@ -54,6 +54,9 @@ public struct TextCell<Accessory>: View
     @Environment(\.formCellCopyable)
     private var isCopyable: Bool
 
+    @Environment(\.formCellIconWidth)
+    private var iconWidth: CGFloat?
+
     internal init(
         icon: Image? = nil,
         title: String,
@@ -76,7 +79,7 @@ public struct TextCell<Accessory>: View
             canShowCell: canShowCell,
             copyableKeyValue: isCopyable ? .init(key: title, value: value) : nil
         ) {
-            icon
+            icon.frame(minWidth: iconWidth, maxWidth: iconWidth)
             Text(title)
             Spacer()
             if let value = value {

--- a/Sources/SherlockForms/FormCells/TextEditorCell.swift
+++ b/Sources/SherlockForms/FormCells/TextEditorCell.swift
@@ -57,6 +57,9 @@ public struct TextEditorCell<Content: View>: View
     @Environment(\.formCellCopyable)
     private var isCopyable: Bool
 
+    @Environment(\.formCellIconWidth)
+    private var iconWidth: CGFloat?
+
     internal init(
         icon: Image? = nil,
         title: String?,
@@ -81,7 +84,7 @@ public struct TextEditorCell<Content: View>: View
             canShowCell: canShowCell,
             copyableKeyValue: isCopyable ? .init(key: title, value: value.wrappedValue) : nil
         ) {
-            icon
+            icon.frame(minWidth: iconWidth, maxWidth: iconWidth)
             if let title = title {
                 Text(title)
                 Spacer(minLength: 16)

--- a/Sources/SherlockForms/FormCells/TextFieldCell.swift
+++ b/Sources/SherlockForms/FormCells/TextFieldCell.swift
@@ -40,6 +40,9 @@ public struct TextFieldCell<Content: View>: View
     @Environment(\.formCellCopyable)
     private var isCopyable: Bool
 
+    @Environment(\.formCellIconWidth)
+    private var iconWidth: CGFloat?
+
     internal init(
         icon: Image? = nil,
         title: String?,
@@ -64,7 +67,7 @@ public struct TextFieldCell<Content: View>: View
             canShowCell: canShowCell,
             copyableKeyValue: isCopyable ? .init(key: title, value: value.wrappedValue) : nil
         ) {
-            icon
+            icon.frame(minWidth: iconWidth, maxWidth: iconWidth)
             if let title = title {
                 Text(title)
                 Spacer(minLength: 16)

--- a/Sources/SherlockForms/FormCells/ToggleCell.swift
+++ b/Sources/SherlockForms/FormCells/ToggleCell.swift
@@ -33,6 +33,9 @@ public struct ToggleCell: View
     @Environment(\.formCellCopyable)
     private var isCopyable: Bool
 
+    @Environment(\.formCellIconWidth)
+    private var iconWidth: CGFloat?
+
     internal init(
         icon: Image? = nil,
         title: String,
@@ -53,7 +56,7 @@ public struct ToggleCell: View
             canShowCell: canShowCell,
             copyableKeyValue: isCopyable ? .init(key: title, value: "\(isOn.wrappedValue)") : nil
         ) {
-            icon
+            icon.frame(minWidth: iconWidth, maxWidth: iconWidth)
             Text(title)
 
             Spacer()

--- a/Sources/SherlockForms/SherlockView.swift
+++ b/Sources/SherlockForms/SherlockView.swift
@@ -1,3 +1,5 @@
+import CoreGraphics
+
 /// A protocol that interacts with ``SherlockForm``.
 @MainActor
 public protocol SherlockView


### PR DESCRIPTION
This PR improves form-cell's icon & text alignment by adding `FormCellIconWidthEnvironmentKey`.

## Screenshot

| Before | After |
|---|---|
|  <img src=https://user-images.githubusercontent.com/138476/155957635-4a141dc5-b637-404a-91e2-9fca04347c33.png  width=300>   |  <img src=https://user-images.githubusercontent.com/138476/155957619-e37df1ff-b2b8-4921-beb8-dbb05c337f74.png  width=300>   |