### PR TITLE
[DebugForms] Fix UserDefaultsListView in iOS14

### DIFF
--- a/Examples/SherlockForms-Gallery-iOS14.xcodeproj/project.pbxproj
+++ b/Examples/SherlockForms-Gallery-iOS14.xcodeproj/project.pbxproj
@@ -1,0 +1,366 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 55;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		33E6235427CE7A2F005E399E /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33E6234F27CE7A2F005E399E /* RootView.swift */; };
+		33E6235527CE7A2F005E399E /* MyApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33E6235027CE7A2F005E399E /* MyApp.swift */; };
+		33E6235627CE7A2F005E399E /* UserDefaultsKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33E6235127CE7A2F005E399E /* UserDefaultsKey.swift */; };
+		33E6235727CE7A2F005E399E /* Constant.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33E6235227CE7A2F005E399E /* Constant.swift */; };
+		33E6235827CE7A2F005E399E /* CustomView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33E6235327CE7A2F005E399E /* CustomView.swift */; };
+		33E6235C27CE7A5F005E399E /* SherlockDebugForms in Frameworks */ = {isa = PBXBuildFile; productRef = 33E6235B27CE7A5F005E399E /* SherlockDebugForms */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		33E6233E27CE79DC005E399E /* SherlockForms-Gallery-iOS14.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "SherlockForms-Gallery-iOS14.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		33E6234F27CE7A2F005E399E /* RootView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RootView.swift; path = "SherlockForms-Gallery.swiftpm/RootView.swift"; sourceTree = SOURCE_ROOT; };
+		33E6235027CE7A2F005E399E /* MyApp.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MyApp.swift; path = "SherlockForms-Gallery.swiftpm/MyApp.swift"; sourceTree = SOURCE_ROOT; };
+		33E6235127CE7A2F005E399E /* UserDefaultsKey.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UserDefaultsKey.swift; path = "SherlockForms-Gallery.swiftpm/UserDefaultsKey.swift"; sourceTree = SOURCE_ROOT; };
+		33E6235227CE7A2F005E399E /* Constant.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Constant.swift; path = "SherlockForms-Gallery.swiftpm/Constant.swift"; sourceTree = SOURCE_ROOT; };
+		33E6235327CE7A2F005E399E /* CustomView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CustomView.swift; path = "SherlockForms-Gallery.swiftpm/CustomView.swift"; sourceTree = SOURCE_ROOT; };
+		33E6235927CE7A55005E399E /* SherlockForms */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = SherlockForms; path = ..; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		33E6233B27CE79DC005E399E /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				33E6235C27CE7A5F005E399E /* SherlockDebugForms in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		33E6233527CE79DC005E399E = {
+			isa = PBXGroup;
+			children = (
+				33E6235927CE7A55005E399E /* SherlockForms */,
+				33E6234027CE79DC005E399E /* SherlockForms-Gallery-iOS14 */,
+				33E6233F27CE79DC005E399E /* Products */,
+				33E6235A27CE7A5F005E399E /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		33E6233F27CE79DC005E399E /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				33E6233E27CE79DC005E399E /* SherlockForms-Gallery-iOS14.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		33E6234027CE79DC005E399E /* SherlockForms-Gallery-iOS14 */ = {
+			isa = PBXGroup;
+			children = (
+				33E6235227CE7A2F005E399E /* Constant.swift */,
+				33E6235327CE7A2F005E399E /* CustomView.swift */,
+				33E6235027CE7A2F005E399E /* MyApp.swift */,
+				33E6234F27CE7A2F005E399E /* RootView.swift */,
+				33E6235127CE7A2F005E399E /* UserDefaultsKey.swift */,
+			);
+			path = "SherlockForms-Gallery-iOS14";
+			sourceTree = "<group>";
+		};
+		33E6235A27CE7A5F005E399E /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		33E6233D27CE79DC005E399E /* SherlockForms-Gallery-iOS14 */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 33E6234C27CE79DF005E399E /* Build configuration list for PBXNativeTarget "SherlockForms-Gallery-iOS14" */;
+			buildPhases = (
+				33E6233A27CE79DC005E399E /* Sources */,
+				33E6233B27CE79DC005E399E /* Frameworks */,
+				33E6233C27CE79DC005E399E /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "SherlockForms-Gallery-iOS14";
+			packageProductDependencies = (
+				33E6235B27CE7A5F005E399E /* SherlockDebugForms */,
+			);
+			productName = "SherlockForms-Gallery-iOS14";
+			productReference = 33E6233E27CE79DC005E399E /* SherlockForms-Gallery-iOS14.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		33E6233627CE79DC005E399E /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1320;
+				LastUpgradeCheck = 1320;
+				TargetAttributes = {
+					33E6233D27CE79DC005E399E = {
+						CreatedOnToolsVersion = 13.2.1;
+						LastSwiftMigration = 1320;
+					};
+				};
+			};
+			buildConfigurationList = 33E6233927CE79DC005E399E /* Build configuration list for PBXProject "SherlockForms-Gallery-iOS14" */;
+			compatibilityVersion = "Xcode 13.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 33E6233527CE79DC005E399E;
+			productRefGroup = 33E6233F27CE79DC005E399E /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				33E6233D27CE79DC005E399E /* SherlockForms-Gallery-iOS14 */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		33E6233C27CE79DC005E399E /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		33E6233A27CE79DC005E399E /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				33E6235827CE7A2F005E399E /* CustomView.swift in Sources */,
+				33E6235627CE7A2F005E399E /* UserDefaultsKey.swift in Sources */,
+				33E6235427CE7A2F005E399E /* RootView.swift in Sources */,
+				33E6235527CE7A2F005E399E /* MyApp.swift in Sources */,
+				33E6235727CE7A2F005E399E /* Constant.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		33E6234A27CE79DF005E399E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		33E6234B27CE79DF005E399E /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		33E6234D27CE79DF005E399E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = UMBZ5WL247;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.inamiy.SherlockForms-Gallery-iOS14";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		33E6234E27CE79DF005E399E /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = UMBZ5WL247;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.inamiy.SherlockForms-Gallery-iOS14";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		33E6233927CE79DC005E399E /* Build configuration list for PBXProject "SherlockForms-Gallery-iOS14" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				33E6234A27CE79DF005E399E /* Debug */,
+				33E6234B27CE79DF005E399E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		33E6234C27CE79DF005E399E /* Build configuration list for PBXNativeTarget "SherlockForms-Gallery-iOS14" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				33E6234D27CE79DF005E399E /* Debug */,
+				33E6234E27CE79DF005E399E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		33E6235B27CE7A5F005E399E /* SherlockDebugForms */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = SherlockDebugForms;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = 33E6233627CE79DC005E399E /* Project object */;
+}

--- a/Examples/SherlockForms-Gallery-iOS14.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Examples/SherlockForms-Gallery-iOS14.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Examples/SherlockForms-Gallery-iOS14.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Examples/SherlockForms-Gallery-iOS14.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Sources/SherlockDebugForms/UserDefaultsListView.swift
+++ b/Sources/SherlockDebugForms/UserDefaultsListView.swift
@@ -139,7 +139,7 @@ public struct UserDefaultsListSectionsView: View, SherlockView
 
     public var body: some View
     {
-        Group {
+        let sections = Group {
             if !recentlyUsedKeys.strings.isEmpty && searchText.isEmpty && maxRecentlyUsedCount > 0 {
                 Section {
                     recentlyUsedKeyValuesView
@@ -157,12 +157,30 @@ public struct UserDefaultsListSectionsView: View, SherlockView
         .onReceive(notifier.objectWillChange) { _ in
             keyValues = userDefaults.getKeyValues()
         }
-        .sheet(unwrapping: $presentingKey) { keyBinding in
-            let key = keyBinding.wrappedValue
-            if let index = keyValues.firstIndex(where: { $0.key == key }) {
-                let value = keyValues[index].value
-                UserDefaultsItemView(key: key, value: value, userDefaults: userDefaults)
-            }
+
+        if #available(iOS 15.0, *) {
+            sections
+                .sheet(unwrapping: $presentingKey) { keyBinding in
+                    let key = keyBinding.wrappedValue
+                    if let index = keyValues.firstIndex(where: { $0.key == key }) {
+                        let value = keyValues[index].value
+                        UserDefaultsItemView(key: key, value: value, userDefaults: userDefaults)
+                    }
+                }
+        }
+        else {
+            // Workaround for iOS 14 `Form`'s inner view + `sheet` breaking table layout.
+            sections
+                .background(
+                    EmptyView()
+                        .sheet(unwrapping: $presentingKey) { keyBinding in
+                            let key = keyBinding.wrappedValue
+                            if let index = keyValues.firstIndex(where: { $0.key == key }) {
+                                let value = keyValues[index].value
+                                UserDefaultsItemView(key: key, value: value, userDefaults: userDefaults)
+                            }
+                        }
+                )
         }
     }
 


### PR DESCRIPTION
This PR fixes `UserDefaultsListView` in iOS14 where Form's cells did not work as expected due to SwiftUI bug
that can't mix Form-inner-view with `.sheet`.

To workaround this, `.background(EmptyView().sheet(...))` is used for iOS 14 in [4cc1bbf](https://github.com/inamiy/SherlockForms/pull/15/commits/4cc1bbf3907865d906e714260ad4f69eba21aef4).

| Before | After |
|---|---|
|   <img src=https://user-images.githubusercontent.com/138476/156204608-a9d6adc5-13fd-4aa6-b201-c946e9096ccb.png  width=300>  |  <img src=https://user-images.githubusercontent.com/138476/156204621-e61d1d16-0f40-4947-af4b-484b3e16014b.png  width=300> |

This PR also adds `Examples/SherlockForms-Gallery-iOS14.xcodeproj` for iOS 14 simulator run in [072ffc9](https://github.com/inamiy/SherlockForms/pull/15/commits/072ffc9f822546ee8a114dd814372067786d76de), where original `.swiftpm` example didn't run well due to the following error:

```
dyld: can't resolve symbol _$sScMMa in /Users/xxx/Library/Developer/CoreSimulator/Devices/3A8F81A3-C365-40A8-98B4-1AC752313AE1/data/Containers/Bundle/Application/B4A105C3-3B65-45D2-92CD-CEAC1B4D3593/SherlockForms-Gallery.app/SherlockForms-Gallery

because dependent dylib @rpath/libswift_Concurrency.dylib could not be loaded
```
