### PR TITLE
[Forms] Add `SimpleList` & `NestedList`

### DIFF
--- a/Examples/SherlockForms-Gallery.swiftpm/ListView.swift
+++ b/Examples/SherlockForms-Gallery.swiftpm/ListView.swift
@@ -1,0 +1,43 @@
+import SwiftUI
+import SherlockForms
+
+/// Simple `SwiftUI.List` example.
+struct ListView: View, SherlockView
+{
+    @State public private(set) var searchText: String = ""
+
+    @State private var items: [ListItem] = (0 ... 3).map { ListItem(content: "Row \($0)") }
+
+    var body: some View
+    {
+        SherlockForm(searchText: $searchText) {
+            simpleList(
+                data: items,
+                rowContent: { item in
+                    Text("\(item.content)")
+                }
+            )
+        }
+        .navigationBarTitleDisplayMode(.inline)
+        .formCellCopyable(true)
+    }
+}
+
+// MARK: - Previews
+
+struct ListView_Previews: PreviewProvider
+{
+    static var previews: some View
+    {
+        ListView()
+    }
+}
+
+// MARK: - Private
+
+private struct ListItem: SimpleListItem, Identifiable
+{
+    let content: String
+
+    var id: String { content }
+}

--- a/Examples/SherlockForms-Gallery.swiftpm/NestedListView.swift
+++ b/Examples/SherlockForms-Gallery.swiftpm/NestedListView.swift
@@ -1,0 +1,64 @@
+import SwiftUI
+import SherlockForms
+
+/// Hierarchical `SwiftUI.List` example.
+struct NestedListView: View, SherlockView
+{
+    @State public private(set) var searchText: String = ""
+
+    @State private var items: [ListItem] = ListItem.presetItems
+
+    var body: some View
+    {
+        SherlockForm(searchText: $searchText) {
+            nestedList(
+                data: items,
+                rowContent: { item in
+                    Text("\(item.content)")
+                }
+            )
+        }
+        .navigationBarTitleDisplayMode(.inline)
+        .formCellCopyable(true)
+    }
+}
+
+// MARK: - Previews
+
+struct NestedListView_Previews: PreviewProvider
+{
+    static var previews: some View
+    {
+        NestedListView()
+    }
+}
+
+// MARK: - Private
+
+private struct ListItem: NestedListItem, Identifiable
+{
+    let content: String
+    var children: [ListItem]?
+
+    var id: String { content }
+
+    init(content: String, children: [ListItem]?)
+    {
+        self.content = content
+        self.children = children
+    }
+
+    static let presetItems: [ListItem] = (0 ... 3).map { i in
+        ListItem(
+            content: "Row \(i)",
+            children: (0 ... 3).map { j in
+                ListItem(
+                    content: "Row \(i)-\(j)",
+                    children: (0 ... 3).map { k in
+                        ListItem(content: "Row \(i)-\(j)-\(k)", children: nil)
+                    }
+                )
+            }
+        )
+    }
+}

--- a/Examples/SherlockForms-Gallery.swiftpm/RootView.swift
+++ b/Examples/SherlockForms-Gallery.swiftpm/RootView.swift
@@ -223,6 +223,12 @@ struct RootView: View, SherlockView
                     CustomView()
                 })
                 navigationLinkCell(icon: icon, title: "Custom Page (Recursive)", destination: RootView.init)
+                navigationLinkCell(icon: icon, title: "Simple List", destination: {
+                    ListView()
+                })
+                navigationLinkCell(icon: icon, title: "Nested List", destination: {
+                    NestedListView()
+                })
             } header: {
                 Text("Navigation Link Cell")
             } footer: {

--- a/Sources/SherlockForms/NestedList/NestedList.swift
+++ b/Sources/SherlockForms/NestedList/NestedList.swift
@@ -1,0 +1,160 @@
+import SwiftUI
+
+// MARK: - Constructors
+
+extension SherlockView
+{
+    /// Creates a hierarchical list that identifies its rows based on a key path to the identifier of the underlying data.
+    ///
+    /// - See: https://developer.apple.com/documentation/swiftui/list/init(_:id:children:rowcontent:)-93wbq
+    @ViewBuilder
+    public func nestedList<Data, ID, RowContent>(
+        data: Data,
+        id: KeyPath<Data.Element, ID>,
+        rowContent: @escaping (Data.Element) -> RowContent
+    ) -> some View
+    where
+        Data: MutableCollection & RangeReplaceableCollection,
+        Data.Element: NestedListItem,
+        ID: Hashable,
+        RowContent: View
+    {
+        NestedList(
+            data: data,
+            id: id,
+            canShowCell: canShowCell,
+            rowContent: rowContent
+        )
+    }
+
+    /// Creates a hierarchical list.
+    @ViewBuilder
+    public func nestedList<Data, RowContent>(
+        data: Data,
+        rowContent: @escaping (Data.Element) -> RowContent
+    ) -> some View
+    where
+        Data: MutableCollection & RangeReplaceableCollection,
+        Data.Element: NestedListItem & Identifiable,
+        Data.Element.ID: Hashable,
+        RowContent: View
+    {
+        nestedList(
+            data: data,
+            id: \.id,
+            rowContent: rowContent
+        )
+    }
+}
+
+// MARK: - NestedList
+
+@MainActor
+private struct NestedList<Data, ID, RowContent>: View
+where
+    Data: MutableCollection & RangeReplaceableCollection,
+    Data.Element: NestedListItem,
+    ID: Hashable,
+    RowContent: View
+{
+    private let data: Data
+    private let id: KeyPath<Data.Element, ID>
+
+    private let canShowCell: @MainActor (_ keywords: [String]) -> Bool
+
+    private let rowContent: (Data.Element) -> RowContent
+
+    @Environment(\.formCellCopyable)
+    private var isCopyable: Bool
+
+    internal init(
+        data: Data,
+        id: KeyPath<Data.Element, ID>,
+        canShowCell: @MainActor @escaping (_ keywords: [String]) -> Bool,
+        rowContent: @escaping (Data.Element) -> RowContent
+    )
+    {
+        self.data = data
+        self.id = id
+        self.canShowCell = canShowCell
+        self.rowContent = rowContent
+    }
+
+    public var body: some View
+    {
+        List(
+            data.compactMap { $0.filter(canShowCell: canShowCell) },
+            id: id,
+            children: \.children,
+            rowContent: { item in
+                if isCopyable, let copyableKeyValue = item.getFormCellCopyableKeyValue() {
+                    rowContent(item)
+                        .modifier(CopyableViewModifier(key: copyableKeyValue.key, value: copyableKeyValue.value))
+                }
+                else {
+                    rowContent(item)
+                }
+            }
+        )
+    }
+}
+
+// MARK: - NestedListItem
+
+/// Recursive protocol that represents displaying nested list items in ``SherlockView/nestedList(data:id:rowContent:)``.
+public protocol NestedListItem
+{
+    associatedtype Content
+
+    /// Content body of the item.
+    var content: Content { get }
+
+    var children: [Self]? { get }
+
+    init(content: Content, children: [Self]?)
+
+    /// Search keywords derived from ``content``.
+    func getKeywords() -> [String]
+
+    /// Copyable key-value pair derived from ``content``.
+    func getFormCellCopyableKeyValue() -> FormCellCopyableKeyValue?
+}
+
+extension NestedListItem where Content: CustomStringConvertible
+{
+    // Default implementation.
+    public func getKeywords() -> [String]
+    {
+        [content.description]
+    }
+
+    public func getFormCellCopyableKeyValue() -> FormCellCopyableKeyValue?
+    {
+        .init(key: content.description)
+    }
+}
+
+extension NestedListItem
+{
+    /// Recursive filtering.
+    /// Rule: If child item matches, then parent item should also be visible.
+    @MainActor
+    fileprivate func filter(
+        canShowCell: @MainActor @escaping (_ keywords: [String]) -> Bool
+    ) -> Self?
+    {
+        if canShowCell(getKeywords()) {
+            return self
+        }
+
+        if let children = children, !children.isEmpty {
+            let filteredChildren = children.compactMap { $0.filter(canShowCell: canShowCell) }
+
+            if !filteredChildren.isEmpty {
+                return Self.init(content: content, children: filteredChildren)
+            }
+        }
+
+        return nil
+    }
+}

--- a/Sources/SherlockForms/NestedList/SimpleList.swift
+++ b/Sources/SherlockForms/NestedList/SimpleList.swift
@@ -1,0 +1,128 @@
+import SwiftUI
+
+// MARK: - Constructors
+
+extension SherlockView
+{
+    /// Creates a simple list that identifies its rows based on a key path to the identifier of the underlying data.
+    @ViewBuilder
+    public func simpleList<Data, ID, RowContent>(
+        data: Data,
+        id: KeyPath<Data.Element, ID>,
+        rowContent: @escaping (Data.Element) -> RowContent
+    ) -> some View
+    where
+        Data: MutableCollection & RangeReplaceableCollection,
+        Data.Element: SimpleListItem,
+        ID: Hashable,
+        RowContent: View
+    {
+        SimpleList(
+            data: data,
+            id: id,
+            canShowCell: canShowCell,
+            rowContent: rowContent
+        )
+    }
+
+    /// Creates a simple list.
+    @ViewBuilder
+    public func simpleList<Data, RowContent>(
+        data: Data,
+        rowContent: @escaping (Data.Element) -> RowContent
+    ) -> some View
+    where
+        Data: MutableCollection & RangeReplaceableCollection,
+        Data.Element: SimpleListItem & Identifiable,
+        Data.Element.ID: Hashable,
+        RowContent: View
+    {
+        simpleList(
+            data: data,
+            id: \.id,
+            rowContent: rowContent
+        )
+    }
+}
+
+// MARK: - SimpleList
+
+@MainActor
+private struct SimpleList<Data, ID, RowContent>: View
+where
+    Data: MutableCollection & RangeReplaceableCollection,
+    Data.Element: SimpleListItem,
+    ID: Hashable,
+    RowContent: View
+{
+    private let data: Data
+    private let id: KeyPath<Data.Element, ID>
+
+    private let canShowCell: @MainActor (_ keywords: [String]) -> Bool
+
+    private let rowContent: (Data.Element) -> RowContent
+
+    @Environment(\.formCellCopyable)
+    private var isCopyable: Bool
+
+    internal init(
+        data: Data,
+        id: KeyPath<Data.Element, ID>,
+        canShowCell: @MainActor @escaping (_ keywords: [String]) -> Bool,
+        rowContent: @escaping (Data.Element) -> RowContent
+    )
+    {
+        self.data = data
+        self.id = id
+        self.canShowCell = canShowCell
+        self.rowContent = rowContent
+    }
+
+    public var body: some View
+    {
+        List(
+            data.filter { canShowCell($0.getKeywords()) },
+            id: id,
+            rowContent: { item in
+                if isCopyable, let copyableKeyValue = item.getFormCellCopyableKeyValue() {
+                    rowContent(item)
+                        .modifier(CopyableViewModifier(key: copyableKeyValue.key, value: copyableKeyValue.value))
+                }
+                else {
+                    rowContent(item)
+                }
+            }
+        )
+    }
+}
+
+// MARK: - SimpleListItem
+
+/// Recursive protocol that represents displaying nested list items in ``SherlockView/list(data:id:rowContent:)``.
+public protocol SimpleListItem
+{
+    associatedtype Content
+
+    /// Content body of the item.
+    var content: Content { get }
+
+    /// Search keywords derived from ``content``.
+    func getKeywords() -> [String]
+
+    /// Copyable key-value pair derived from ``content``.
+    func getFormCellCopyableKeyValue() -> FormCellCopyableKeyValue?
+}
+
+extension SimpleListItem where Content: CustomStringConvertible
+{
+    // Default implementation.
+    public func getKeywords() -> [String]
+    {
+        [content.description]
+    }
+
+    public func getFormCellCopyableKeyValue() -> FormCellCopyableKeyValue?
+    {
+        .init(key: content.description)
+    }
+}


### PR DESCRIPTION
This PR adds `SimpleList` & `NestedList` which is derived from `SwiftUI.List` for searchable & copyable component.

See example app for more info.

## Screencast

https://user-images.githubusercontent.com/138476/181136608-c76a53e2-9bfd-4ff0-895d-455acb8c3820.MP4


